### PR TITLE
Fixed renamed func in index_test

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -11,7 +11,7 @@ func TestCreateRepoAndStage(t *testing.T) {
 	// figure out where we can create the test repo
 	path, err := ioutil.TempDir("", "git2go")
 	checkFatal(t, err)
-	repo, err := Init(path, false)
+	repo, err := InitRepository(path, false)
 	checkFatal(t, err)
 
 	tmpfile := "README"


### PR DESCRIPTION
Looks like a func rename didn't get applied to the test file included. This fixes it, and tests pass.
