### PR TITLE
Oid: make sure not to dereference a NULL git_oid

### DIFF
--- a/git.go
+++ b/git.go
@@ -26,6 +26,10 @@ type Oid struct {
 }
 
 func newOidFromC(coid *C.git_oid) *Oid {
+	if coid == nil {
+		return nil
+	}
+
 	oid := new(Oid)
 	copy(oid.bytes[0:20], C.GoBytes(unsafe.Pointer(coid), 20))
 	return oid

--- a/reference_test.go
+++ b/reference_test.go
@@ -43,9 +43,21 @@ func TestRefModification(t *testing.T) {
 	checkFatal(t, err)
 	checkRefType(t, ref, SYMBOLIC)
 
+	if target := ref.Target(); target != nil {
+		t.Fatalf("Expected nil *Oid, got %v", target)
+	}
+
 	ref, err = ref.Resolve()
 	checkFatal(t, err)
 	checkRefType(t, ref, OID)
+
+	if target := ref.Target(); target == nil {
+		t.Fatalf("Expected valid target got nil")
+	}
+
+	if target := ref.SymbolicTarget(); target != "" {
+		t.Fatalf("Expected empty string, got %v", target)
+	}
 
 	if commitId.String() != ref.Target().String() {
 		t.Fatalf("Wrong ref target")


### PR DESCRIPTION
Some calls like Reference.Target() can return NULL if the reference is
symbolic. Make sure newOidFromC() can handle these situations.

---

I couldn't decide whether we should return nil or a zeroed Oid in this case. A zeroed id won't make you segfault, but it could lead to the code assuming it has a proper id. Thoughts?
