### PR TITLE
Give gitObject.Free a pointer-receiver

### DIFF
--- a/object.go
+++ b/object.go
@@ -37,7 +37,7 @@ func (o gitObject) Type() ObjectType {
 	return ObjectType(C.git_object_type(o.ptr))
 }
 
-func (o gitObject) Free() {
+func (o *gitObject) Free() {
 	runtime.SetFinalizer(o, nil)
 	C.git_commit_free(o.ptr)
 }


### PR DESCRIPTION
This is needed to get runtime.SetFinalizer to work, which
expects a pointer-receiver. Without it the runtime will crash, when it
tries to garbage-collect an object.
