### PR TITLE
Implement a reference iterator

### DIFF
--- a/git.go
+++ b/git.go
@@ -8,6 +8,7 @@ package git
 import "C"
 import (
 	"bytes"
+	"errors"
 	"unsafe"
 	"strings"
 )
@@ -16,6 +17,10 @@ const (
 	ITEROVER  = C.GIT_ITEROVER
 	EEXISTS   = C.GIT_EEXISTS
 	ENOTFOUND = C.GIT_ENOTFOUND
+)
+
+var (
+	ErrIterOver = errors.New("Iteration is over")
 )
 
 func init() {

--- a/reference_test.go
+++ b/reference_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"os"
 	"runtime"
+	"sort"
 	"testing"
 	"time"
 )
@@ -69,6 +70,97 @@ func TestRefModification(t *testing.T) {
 	checkFatal(t, err)
 	checkRefType(t, ref, OID)
 
+}
+
+func TestIterator(t *testing.T) {
+	repo := createTestRepo(t)
+	defer os.RemoveAll(repo.Workdir())
+
+	loc, err := time.LoadLocation("Europe/Berlin")
+	checkFatal(t, err)
+	sig := &Signature{
+		Name:  "Rand Om Hacker",
+		Email: "random@hacker.com",
+		When:  time.Date(2013, 03, 06, 14, 30, 0, 0, loc),
+	}
+
+	idx, err := repo.Index()
+	checkFatal(t, err)
+	err = idx.AddByPath("README")
+	checkFatal(t, err)
+	treeId, err := idx.WriteTree()
+	checkFatal(t, err)
+
+	message := "This is a commit\n"
+	tree, err := repo.LookupTree(treeId)
+	checkFatal(t, err)
+	commitId, err := repo.CreateCommit("HEAD", sig, sig, message, tree)
+	checkFatal(t, err)
+
+	_, err = repo.CreateReference("refs/heads/one", commitId, true)
+	checkFatal(t, err)
+
+	_, err = repo.CreateReference("refs/heads/two", commitId, true)
+	checkFatal(t, err)
+
+	_, err = repo.CreateReference("refs/heads/three", commitId, true)
+	checkFatal(t, err)
+
+	iter, err := repo.NewReferenceIterator()
+	checkFatal(t, err)
+
+	var list []string
+	expected := []string{
+		"refs/heads/master",
+		"refs/heads/one",
+		"refs/heads/three",
+		"refs/heads/two",
+	}
+
+	// test some manual iteration
+	name, err := iter.Next()
+	for err == nil {
+		list = append(list, name)
+		name, err = iter.Next()
+	}
+	if err != ErrIterOver {
+		t.Fatal("Iteration not over")
+	}
+
+
+	sort.Strings(list)
+	compareStringList(t, expected, list)
+
+	// test the channel iteration
+	list = []string{}
+	iter, err = repo.NewReferenceIterator()
+	for name := range iter.Iter() {
+		list = append(list, name)
+	}
+
+	sort.Strings(list)
+	compareStringList(t, expected, list)
+
+	iter, err = repo.NewReferenceIteratorGlob("refs/heads/t*")
+	expected = []string{
+		"refs/heads/three",
+		"refs/heads/two",
+	}
+
+	list = []string{}
+	for name := range iter.Iter() {
+		list = append(list, name)
+	}
+
+	compareStringList(t, expected, list)
+}
+
+func compareStringList(t *testing.T, expected, actual []string) {
+	for i, v := range expected {
+		if actual[i] != v {
+			t.Fatalf("Bad list")
+		}
+	}
 }
 
 func checkRefType(t *testing.T, ref *Reference, kind int) {


### PR DESCRIPTION
Wrap the reference iterators, and provide a Iter() function to get
them through a channel.
