### PR TITLE
Implement ShortenOids

### DIFF
--- a/git.go
+++ b/git.go
@@ -96,6 +96,26 @@ func (oid *Oid) NCmp(oid2 *Oid, n uint) int {
 	return bytes.Compare(oid.bytes[:n], oid2.bytes[:n])
 }
 
+func ShortenOids(ids []*Oid, minlen int) (int, error) {
+	shorten := C.git_oid_shorten_new(C.size_t(minlen))
+	if shorten == nil {
+		panic("Out of memory")
+	}
+	defer C.git_oid_shorten_free(shorten)
+
+	var ret C.int
+	for _, id := range ids {
+		buf := make([]byte, 41)
+		C.git_oid_fmt((*C.char)(unsafe.Pointer(&buf[0])), id.toC())
+		buf[40] = 0
+		ret = C.git_oid_shorten_add(shorten, (*C.char)(unsafe.Pointer(&buf[0])))
+		if ret < 0 {
+			return int(ret), LastError()
+		}
+	}
+	return int(ret), nil
+}
+
 type GitError struct {
 	Message string
 	Code int


### PR DESCRIPTION
Add some code to shorten oids. We could do that in pure go in the longrun (should be faster), but for now we just call what libgit2 gives us.

I'm not sure if libgit2 does some clever tricks that permits calculating this without keeping every oid in memory, which might make this code scale worse than pure libgit, but for now it's okay I guess.
