### PR TITLE
Add nil for optional arguments to git_packbuilder_write

### DIFF
--- a/packbuilder.go
+++ b/packbuilder.go
@@ -11,9 +11,9 @@ extern int _go_git_packbuilder_foreach(git_packbuilder *pb, void *payload);
 */
 import "C"
 import (
+	"io"
 	"runtime"
 	"unsafe"
-	"io"
 )
 
 type Packbuilder struct {
@@ -68,7 +68,7 @@ func (pb *Packbuilder) ObjectCount() uint32 {
 func (pb *Packbuilder) WriteToFile(name string) error {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
-	ret := C.git_packbuilder_write(pb.ptr, cname)
+	ret := C.git_packbuilder_write(pb.ptr, cname, nil, nil)
 	if ret != 0 {
 		return LastError()
 	}


### PR DESCRIPTION
The git_packbuilder_write function now takes
two optional arguments used for information
callbacks.  These are currently not needed
in the Go wrapper.

Without this patch you cannot build git2go.
