### PR TITLE
reference: get references out of the iterator

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -147,7 +147,7 @@ func (repo *Repository) NewReferenceIteratorGlob(glob string) (*ReferenceIterato
 	return iter, nil
 }
 
-// Next retrieves the next reference name. If the iteration is over,
+// NextName retrieves the next reference name. If the iteration is over,
 // the returned error is git.ErrIterOver
 func (v *ReferenceIterator) NextName() (string, error) {
 	var ptr *C.char
@@ -173,6 +173,38 @@ func (v *ReferenceIterator) NameIter() <-chan string {
 		for err == nil {
 			ch <- name
 			name, err = v.NextName()
+		}
+	}()
+
+	return ch
+}
+
+// Next retrieves the next reference. If the iterationis over, the
+// returned error is git.ErrIterOver
+func (v *ReferenceIterator) Next() (*Reference, error) {
+	var ptr *C.git_reference
+	ret := C.git_reference_next(&ptr, v.ptr)
+	if ret == ITEROVER {
+		return nil, ErrIterOver
+	}
+	if ret < 0 {
+		return nil, LastError()
+	}
+
+	return newReferenceFromC(ptr), nil
+}
+
+// Create a channel from the iterator. You can use range on the
+// returned channel to iterate over all the references names. The channel
+// will be closed in case any error is found.
+func (v *ReferenceIterator) Iter() <-chan *Reference {
+	ch := make(chan *Reference)
+	go func() {
+		defer close(ch)
+		name, err := v.Next()
+		for err == nil {
+			ch <- name
+			name, err = v.Next()
 		}
 	}()
 

--- a/reference_test.go
+++ b/reference_test.go
@@ -112,6 +112,24 @@ func TestIterator(t *testing.T) {
 	sort.Strings(list)
 	compareStringList(t, expected, list)
 
+	// test the iterator for full refs, rather than just names
+	iter, err = repo.NewReferenceIterator()
+	checkFatal(t, err)
+	count := 0
+	_, err = iter.Next()
+	for err == nil {
+		count++
+		_, err = iter.Next()
+	}
+	if err != ErrIterOver {
+		t.Fatal("Iteration not over")
+	}
+
+	if count != 4 {
+		t.Fatalf("Wrong number of references returned %v", count)
+	}
+
+
 	// test the channel iteration
 	list = []string{}
 	iter, err = repo.NewReferenceIterator()


### PR DESCRIPTION
Allow getting references out of the iterator instead of just names.
