### PR TITLE
Lock the OS thread when acessing errors

### DIFF
--- a/checkout.go
+++ b/checkout.go
@@ -9,6 +9,7 @@ git_checkout_opts git_checkout_opts_init() {
 */
 import "C"
 import (
+	"runtime"
 	"os"
 )
 
@@ -59,6 +60,9 @@ func (v *Repository) Checkout(opts *CheckoutOpts) error {
 	var copts C.git_checkout_opts
 	populateCheckoutOpts(&copts, opts)
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_checkout_head(v.ptr, &copts)
 	if ret < 0 {
 		return LastError()
@@ -71,6 +75,9 @@ func (v *Repository) Checkout(opts *CheckoutOpts) error {
 func (v *Repository) CheckoutIndex(index *Index, opts *CheckoutOpts) error {
 	var copts C.git_checkout_opts
 	populateCheckoutOpts(&copts, opts)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ret := C.git_checkout_index(v.ptr, index.ptr, &copts)
 	if ret < 0 {

--- a/commit.go
+++ b/commit.go
@@ -9,6 +9,7 @@ extern int _go_git_treewalk(git_tree *tree, git_treewalk_mode mode, void *ptr);
 import "C"
 
 import (
+	"runtime"
 	"time"
 	"unsafe"
 )
@@ -24,6 +25,9 @@ func (c Commit) Message() string {
 
 func (c Commit) Tree() (*Tree, error) {
 	var ptr *C.git_object
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	err := C.git_commit_tree(&ptr, c.ptr)
 	if err < 0 {

--- a/config.go
+++ b/config.go
@@ -19,6 +19,9 @@ func (c *Config) LookupInt32(name string) (v int32, err error) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_config_get_int32(&out, c.ptr, cname)
 	if ret < 0 {
 		return 0, LastError()
@@ -32,6 +35,9 @@ func (c *Config) LookupInt64(name string) (v int64, err error) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_config_get_int64(&out, c.ptr, cname)
 	if ret < 0 {
 		return 0, LastError()
@@ -44,6 +50,9 @@ func (c *Config) LookupString(name string) (v string, err error) {
 	var ptr *C.char
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ret := C.git_config_get_string(&ptr, c.ptr, cname)
 	if ret < 0 {
@@ -59,6 +68,9 @@ func (c *Config) Set(name, value string) (err error) {
 
 	cvalue := C.CString(value)
 	defer C.free(unsafe.Pointer(cvalue))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ret := C.git_config_set_string(c.ptr, cname, cvalue)
 	if ret < 0 {

--- a/index.go
+++ b/index.go
@@ -24,6 +24,9 @@ func (v *Index) AddByPath(path string) error {
 	cstr := C.CString(path)
 	defer C.free(unsafe.Pointer(cstr))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_index_add_bypath(v.ptr, cstr)
 	if ret < 0 {
 		return LastError()
@@ -34,6 +37,10 @@ func (v *Index) AddByPath(path string) error {
 
 func (v *Index) WriteTree() (*Oid, error) {
 	oid := new(Oid)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_index_write_tree(oid.toC(), v.ptr)
 	if ret < 0 {
 		return nil, LastError()

--- a/odb.go
+++ b/odb.go
@@ -25,6 +25,10 @@ func (v *Odb) Exists(oid *Oid) bool {
 func (v *Odb) Write(data []byte, otype ObjectType) (oid *Oid, err error) {
 	oid = new(Oid)
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_odb_write(oid.toC(), v.ptr, unsafe.Pointer(hdr.Data), C.size_t(hdr.Len), C.git_otype(otype))
 
 	if ret < 0 {
@@ -36,6 +40,10 @@ func (v *Odb) Write(data []byte, otype ObjectType) (oid *Oid, err error) {
 
 func (v *Odb) Read(oid *Oid) (obj *OdbObject, err error) {
 	obj = new(OdbObject)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_odb_read(&obj.ptr, v.ptr, oid.toC())
 	if ret < 0 {
 		return nil, LastError()

--- a/packbuilder.go
+++ b/packbuilder.go
@@ -22,6 +22,10 @@ type Packbuilder struct {
 
 func (repo *Repository) NewPackbuilder() (*Packbuilder, error) {
 	builder := &Packbuilder{}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_packbuilder_new(&builder.ptr, repo.ptr)
 	if ret != 0 {
 		return nil, LastError()
@@ -38,6 +42,10 @@ func (pb *Packbuilder) Free() {
 func (pb *Packbuilder) Insert(id *Oid, name string) error {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_packbuilder_insert(pb.ptr, id.toC(), cname)
 	if ret != 0 {
 		return LastError()
@@ -46,6 +54,9 @@ func (pb *Packbuilder) Insert(id *Oid, name string) error {
 }
 
 func (pb *Packbuilder) InsertCommit(id *Oid) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_packbuilder_insert_commit(pb.ptr, id.toC())
 	if ret != 0 {
 		return LastError()
@@ -54,6 +65,9 @@ func (pb *Packbuilder) InsertCommit(id *Oid) error {
 }
 
 func (pb *Packbuilder) InsertTree(id *Oid) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_packbuilder_insert_tree(pb.ptr, id.toC())
 	if ret != 0 {
 		return LastError()
@@ -68,6 +82,10 @@ func (pb *Packbuilder) ObjectCount() uint32 {
 func (pb *Packbuilder) WriteToFile(name string, mode os.FileMode) error {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_packbuilder_write(pb.ptr, cname, C.uint(mode.Perm()), nil, nil)
 	if ret != 0 {
 		return LastError()

--- a/reference.go
+++ b/reference.go
@@ -32,6 +32,9 @@ func (v *Reference) SetSymbolicTarget(target string) (*Reference, error) {
 	ctarget := C.CString(target)
 	defer C.free(unsafe.Pointer(ctarget))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_reference_symbolic_set_target(&ptr, v.ptr, ctarget)
 	if ret < 0 {
 		return nil, LastError()
@@ -43,6 +46,9 @@ func (v *Reference) SetSymbolicTarget(target string) (*Reference, error) {
 func (v *Reference) SetTarget(target *Oid) (*Reference, error) {
 	var ptr *C.git_reference
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_reference_set_target(&ptr, v.ptr, target.toC())
 	if ret < 0 {
 		return nil, LastError()
@@ -53,6 +59,9 @@ func (v *Reference) SetTarget(target *Oid) (*Reference, error) {
 
 func (v *Reference) Resolve() (*Reference, error) {
 	var ptr *C.git_reference
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ret := C.git_reference_resolve(&ptr, v.ptr)
 	if ret < 0 {
@@ -66,6 +75,9 @@ func (v *Reference) Rename(name string, force bool) (*Reference, error) {
 	var ptr *C.git_reference
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ret := C.git_reference_rename(&ptr, v.ptr, cname, cbool(force))
 
@@ -90,6 +102,9 @@ func (v *Reference) SymbolicTarget() string {
 }
 
 func (v *Reference) Delete() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_reference_delete(v.ptr)
 
 	if ret < 0 {
@@ -120,6 +135,10 @@ type ReferenceIterator struct {
 // NewReferenceIterator creates a new iterator over reference names
 func (repo *Repository) NewReferenceIterator() (*ReferenceIterator, error) {
 	var ptr *C.git_reference_iterator
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_reference_iterator_new(&ptr, repo.ptr)
 	if ret < 0 {
 		return nil, LastError()
@@ -137,6 +156,10 @@ func (repo *Repository) NewReferenceIteratorGlob(glob string) (*ReferenceIterato
 	cstr := C.CString(glob)
 	defer C.free(unsafe.Pointer(cstr))
 	var ptr *C.git_reference_iterator
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_reference_iterator_glob_new(&ptr, repo.ptr, cstr)
 	if ret < 0 {
 		return nil, LastError()
@@ -151,6 +174,10 @@ func (repo *Repository) NewReferenceIteratorGlob(glob string) (*ReferenceIterato
 // the returned error is git.ErrIterOver
 func (v *ReferenceIterator) NextName() (string, error) {
 	var ptr *C.char
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_reference_next_name(&ptr, v.ptr)
 	if ret == ITEROVER {
 		return "", ErrIterOver

--- a/repository.go
+++ b/repository.go
@@ -21,6 +21,9 @@ func OpenRepository(path string) (*Repository, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_repository_open(&repo.ptr, cpath)
 	if ret < 0 {
 		return nil, LastError()
@@ -35,6 +38,9 @@ func InitRepository(path string, isbare bool) (*Repository, error) {
 
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_init(&repo.ptr, cpath, ucbool(isbare))
 	if ret < 0 {
@@ -53,6 +59,9 @@ func (v *Repository) Free() {
 func (v *Repository) Config() (*Config, error) {
 	config := new(Config)
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_repository_config(&config.ptr, v.ptr)
 	if ret < 0 {
 		return nil, LastError()
@@ -64,6 +73,10 @@ func (v *Repository) Config() (*Config, error) {
 
 func (v *Repository) Index() (*Index, error) {
 	var ptr *C.git_index
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_repository_index(&ptr, v.ptr)
 	if ret < 0 {
 		return nil, LastError()
@@ -74,6 +87,10 @@ func (v *Repository) Index() (*Index, error) {
 
 func (v *Repository) lookupType(oid *Oid, t ObjectType) (Object, error) {
 	var ptr *C.git_object
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_object_lookup(&ptr, v.ptr, oid.toC(), C.git_otype(t))
 	if ret < 0 {
 		return nil, LastError()
@@ -118,6 +135,9 @@ func (v *Repository) LookupReference(name string) (*Reference, error) {
 	defer C.free(unsafe.Pointer(cname))
 	var ptr *C.git_reference
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ecode := C.git_reference_lookup(&ptr, v.ptr, cname)
 	if ecode < 0 {
 		return nil, LastError()
@@ -130,6 +150,9 @@ func (v *Repository) CreateReference(name string, oid *Oid, force bool) (*Refere
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 	var ptr *C.git_reference
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ecode := C.git_reference_create(&ptr, v.ptr, cname, oid.toC(), cbool(force))
 	if ecode < 0 {
@@ -146,6 +169,9 @@ func (v *Repository) CreateSymbolicReference(name, target string, force bool) (*
 	defer C.free(unsafe.Pointer(ctarget))
 	var ptr *C.git_reference
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ecode := C.git_reference_symbolic_create(&ptr, v.ptr, cname, ctarget, cbool(force))
 	if ecode < 0 {
 		return nil, LastError()
@@ -156,6 +182,10 @@ func (v *Repository) CreateSymbolicReference(name, target string, force bool) (*
 
 func (v *Repository) Walk() (*RevWalk, error) {
 	walk := new(RevWalk)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ecode := C.git_revwalk_new(&walk.ptr, v.ptr)
 	if ecode < 0 {
 		return nil, LastError()
@@ -196,6 +226,9 @@ func (v *Repository) CreateCommit(
 	committerSig := committer.toC()
 	defer C.git_signature_free(committerSig)
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_commit_create(
 		oid.toC(), v.ptr, cref,
 		authorSig, committerSig,
@@ -215,6 +248,10 @@ func (v *Odb) Free() {
 
 func (v *Repository) Odb() (odb *Odb, err error) {
 	odb = new(Odb)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if ret := C.git_repository_odb(&odb.ptr, v.ptr); ret < 0 {
 		return nil, LastError()
 	}
@@ -239,6 +276,9 @@ func (repo *Repository) SetWorkdir(workdir string, updateGitlink bool) error {
 	cstr := C.CString(workdir)
 	defer C.free(unsafe.Pointer(cstr))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if C.git_repository_set_workdir(repo.ptr, cstr, cbool(updateGitlink)) < 0 {
 		return LastError()
 	}
@@ -247,6 +287,10 @@ func (repo *Repository) SetWorkdir(workdir string, updateGitlink bool) error {
 
 func (v *Repository) TreeBuilder() (*TreeBuilder, error) {
 	bld := new(TreeBuilder)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if ret := C.git_treebuilder_create(&bld.ptr, nil); ret < 0 {
 		return nil, LastError()
 	}
@@ -261,6 +305,10 @@ func (v *Repository) RevparseSingle(spec string) (Object, error) {
 	defer C.free(unsafe.Pointer(cspec))
 
 	var ptr *C.git_object
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ecode := C.git_revparse_single(&ptr, v.ptr, cspec)
 	if ecode < 0 {
 		return nil, LastError()

--- a/submodule.go
+++ b/submodule.go
@@ -8,6 +8,7 @@ extern int _go_git_visit_submodule(git_repository *repo, void *fct);
 */
 import "C"
 import (
+	"runtime"
 	"unsafe"
 )
 
@@ -66,6 +67,10 @@ func (repo *Repository) LookupSubmodule(name string) (*Submodule, error) {
 	defer C.free(unsafe.Pointer(cname))
 
 	sub := new(Submodule)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_lookup(&sub.ptr, repo.ptr, cname)
 	if ret < 0 {
 		return nil, LastError()
@@ -84,6 +89,9 @@ func SubmoduleVisitor(csub unsafe.Pointer, name string, cfct unsafe.Pointer) int
 }
 
 func (repo *Repository) ForeachSubmodule(cbk SubmoduleCbk) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C._go_git_visit_submodule(repo.ptr, unsafe.Pointer(&cbk))
 	if ret < 0 {
 		return LastError()
@@ -98,6 +106,10 @@ func (repo *Repository) AddSubmodule(url, path string, use_git_link bool) (*Subm
 	defer C.free(unsafe.Pointer(cpath))
 
 	sub := new(Submodule)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_add_setup(&sub.ptr, repo.ptr, curl, cpath, cbool(use_git_link))
 	if ret < 0 {
 		return nil, LastError()
@@ -106,6 +118,9 @@ func (repo *Repository) AddSubmodule(url, path string, use_git_link bool) (*Subm
 }
 
 func (sub *Submodule) FinalizeAdd() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_add_finalize(sub.ptr)
 	if ret < 0 {
 		return LastError()
@@ -114,6 +129,9 @@ func (sub *Submodule) FinalizeAdd() error {
 }
 
 func (sub *Submodule) AddToIndex(write_index bool) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_add_to_index(sub.ptr, cbool(write_index))
 	if ret < 0 {
 		return LastError()
@@ -122,6 +140,9 @@ func (sub *Submodule) AddToIndex(write_index bool) error {
 }
 
 func (sub *Submodule) Save() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_save(sub.ptr)
 	if ret < 0 {
 		return LastError()
@@ -153,6 +174,9 @@ func (sub *Submodule) Url() string {
 func (sub *Submodule) SetUrl(url string) error {
 	curl := C.CString(url)
 	defer C.free(unsafe.Pointer(curl))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	ret := C.git_submodule_set_url(sub.ptr, curl)
 	if ret < 0 {
@@ -213,6 +237,9 @@ func (sub *Submodule) FetchRecurseSubmodules() bool {
 }
 
 func (sub *Submodule) SetFetchRecurseSubmodules(v bool) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_set_fetch_recurse_submodules(sub.ptr, cbool(v))
 	if ret < 0 {
 		return LastError()
@@ -221,6 +248,9 @@ func (sub *Submodule) SetFetchRecurseSubmodules(v bool) error {
 }
 
 func (sub *Submodule) Init(overwrite bool) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_init(sub.ptr, cbool(overwrite))
 	if ret < 0 {
 		return LastError()
@@ -229,6 +259,9 @@ func (sub *Submodule) Init(overwrite bool) error {
 }
 
 func (sub *Submodule) Sync() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_sync(sub.ptr)
 	if ret < 0 {
 		return LastError()
@@ -238,6 +271,10 @@ func (sub *Submodule) Sync() error {
 
 func (sub *Submodule) Open() (*Repository, error) {
 	repo := new(Repository)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_open(&repo.ptr, sub.ptr)
 	if ret < 0 {
 		return nil, LastError()
@@ -246,6 +283,9 @@ func (sub *Submodule) Open() (*Repository, error) {
 }
 
 func (sub *Submodule) Reload() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_reload(sub.ptr)
 	if ret < 0 {
 		return LastError()
@@ -254,6 +294,9 @@ func (sub *Submodule) Reload() error {
 }
 
 func (repo *Repository) ReloadAllSubmodules() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_submodule_reload_all(repo.ptr)
 	if ret < 0 {
 		return LastError()

--- a/tree.go
+++ b/tree.go
@@ -62,6 +62,9 @@ func (t Tree) EntryByPath(path string) (*TreeEntry, error) {
 	defer C.free(unsafe.Pointer(cpath))
 	var entry *C.git_tree_entry
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_tree_entry_bypath(&entry, t.ptr, cpath)
 	if ret < 0 {
 		return nil, LastError()
@@ -96,6 +99,9 @@ func CallbackGitTreeWalk(_root unsafe.Pointer, _entry unsafe.Pointer, ptr unsafe
 }
 
 func (t Tree) Walk(callback TreeWalkCallback) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	err := C._go_git_treewalk(
 		t.ptr,
 		C.GIT_TREEWALK_PRE,
@@ -123,6 +129,9 @@ func (v *TreeBuilder) Insert(filename string, id *Oid, filemode int) (error) {
 	cfilename := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfilename))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	err := C.git_treebuilder_insert(nil, v.ptr, cfilename, id.toC(), C.git_filemode_t(filemode))
 	if err < 0 {
 		return LastError()
@@ -133,6 +142,10 @@ func (v *TreeBuilder) Insert(filename string, id *Oid, filemode int) (error) {
 
 func (v *TreeBuilder) Write() (*Oid, error) {
 	oid := new(Oid)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	err := C.git_treebuilder_write(oid.toC(), v.repo.ptr, v.ptr)
 
 	if err < 0 {

--- a/walk.go
+++ b/walk.go
@@ -8,6 +8,7 @@ import "C"
 
 import (
 	"io"
+	"runtime"
 )
 
 // RevWalk
@@ -34,6 +35,9 @@ func (v *RevWalk) Push(id *Oid) {
 }
 
 func (v *RevWalk) PushHead() (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ecode := C.git_revwalk_push_head(v.ptr)
 	if ecode < 0 {
 		err = LastError()
@@ -43,6 +47,9 @@ func (v *RevWalk) PushHead() (err error) {
 }
 
 func (v *RevWalk) Next(oid *Oid) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ret := C.git_revwalk_next(oid.toC(), v.ptr)
 	switch {
 	case ret == ITEROVER:


### PR DESCRIPTION
The library stores error information in thread-local storage, which
means we need to make sure that the Go runtime doesn't switch OS
threads between the time we call a function and th time we attempt to
retrieve the error information.

@vmg this is what I was talking about in the other PR. It's either this or wrap every single function with our own C wrapper that copies the error.
