### PR TITLE
Return the same index and odb objects in successive calls

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -22,6 +22,20 @@ func TestCreateRepoAndStage(t *testing.T) {
 	}
 }
 
+func TestIndexTwoCalls(t *testing.T) {
+	repo := createTestRepo(t)
+	defer os.RemoveAll(repo.Workdir())
+
+	idx1, err := repo.Index()
+	checkFatal(t, err)
+	idx2, err := repo.Index()
+	checkFatal(t, err)
+
+	if idx1 != idx2 {
+		t.Fatal("Two Index() calls give different objects")
+	}
+}
+
 func checkFatal(t *testing.T, err error) {
 	if err == nil {
 		return

--- a/odb.go
+++ b/odb.go
@@ -17,6 +17,12 @@ type Odb struct {
 	ptr *C.git_odb
 }
 
+func newOdbFromC(ptr *C.git_odb) *Odb {
+	odb := &Odb{ptr}
+	runtime.SetFinalizer(odb, (*Odb).Free)
+	return odb
+}
+
 func (v *Odb) Exists(oid *Oid) bool {
 	ret := C.git_odb_exists(v.ptr, oid.toC())
 	return ret != 0

--- a/odb_test.go
+++ b/odb_test.go
@@ -33,3 +33,17 @@ func TestOdbStream(t *testing.T) {
 		t.Fatal("Wrong data written")
 	}
 }
+
+func TestOdbTwoCalls(t *testing.T) {
+	repo := createTestRepo(t)
+	defer os.RemoveAll(repo.Workdir())
+
+	odb1, err := repo.Odb()
+	checkFatal(t, err)
+	odb2, err := repo.Odb()
+	checkFatal(t, err)
+
+	if odb1 != odb2 {
+		t.Fatal("Two Odb() calls return different objects")
+	}
+}

--- a/submodule.go
+++ b/submodule.go
@@ -153,7 +153,7 @@ func (sub *Submodule) Save() error {
 func (sub *Submodule) Owner() *Repository {
 	repo := C.git_submodule_owner(sub.ptr)
 	//FIXME: how to handle dangling references ?
-	return &Repository{repo}
+	return &Repository{ptr: repo}
 }
 
 func (sub *Submodule) Name() string {


### PR DESCRIPTION
Instead of creating a new Go object each time Repository.Index()/Odb()
are called, keep track of the first one we created and keep returning
that.
