### PR TITLE
added write method to index

### DIFF
--- a/index.go
+++ b/index.go
@@ -49,6 +49,18 @@ func (v *Index) WriteTree() (*Oid, error) {
 	return oid, nil
 }
 
+func (v *Index) Write() (error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	ret := C.git_index_write(v.ptr)
+	if ret < 0 {
+		return LastError()
+	}
+
+	return nil
+}
+
 func (v *Index) Free() {
 	runtime.SetFinalizer(v, nil)
 	C.git_index_free(v.ptr)


### PR DESCRIPTION
According to the following issue: https://github.com/libgit2/rugged/issues/254 you have to write out your index or you end up with a "weird" commit status when manually creating a commit object.

Is that the right approach after manually crafting a commit?

Tobscher
