### PR TITLE
update git2go to support latest libgit2 development commit (id: 66af84)

### DIFF
--- a/git.go
+++ b/git.go
@@ -9,8 +9,8 @@ import "C"
 import (
 	"bytes"
 	"errors"
-	"unsafe"
 	"strings"
+	"unsafe"
 )
 
 const (
@@ -89,7 +89,7 @@ func (oid *Oid) Equal(oid2 *Oid) bool {
 }
 
 func (oid *Oid) IsZero() bool {
-	for _, a := range(oid.bytes) {
+	for _, a := range oid.bytes {
 		if a != '0' {
 			return false
 		}
@@ -123,10 +123,10 @@ func ShortenOids(ids []*Oid, minlen int) (int, error) {
 
 type GitError struct {
 	Message string
-	Code int
+	Code    int
 }
 
-func (e GitError) Error() string{
+func (e GitError) Error() string {
 	return e.Message
 }
 
@@ -139,14 +139,14 @@ func LastError() error {
 }
 
 func cbool(b bool) C.int {
-	if (b) {
+	if b {
 		return C.int(1)
 	}
 	return C.int(0)
 }
 
 func ucbool(b bool) C.uint {
-	if (b) {
+	if b {
 		return C.uint(1)
 	}
 	return C.uint(0)
@@ -159,13 +159,13 @@ func Discover(start string, across_fs bool, ceiling_dirs []string) (string, erro
 	cstart := C.CString(start)
 	defer C.free(unsafe.Pointer(cstart))
 
-	retpath := (*C.char)(C.malloc(C.GIT_PATH_MAX))
-	defer C.free(unsafe.Pointer(retpath))
+	retpath := (*C.git_buf)(C.malloc(C.GIT_PATH_MAX))
+	defer C.git_buf_free(retpath)
 
-	r := C.git_repository_discover(retpath, C.GIT_PATH_MAX, cstart, cbool(across_fs), ceildirs)
+	r := C.git_repository_discover(retpath, cstart, cbool(across_fs), ceildirs)
 
 	if r == 0 {
-		return C.GoString(retpath), nil
+		return C.GoString(retpath.ptr), nil
 	}
 
 	return "", LastError()

--- a/reference.go
+++ b/reference.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ReferenceType int
+
 const (
 	ReferenceSymbolic ReferenceType = C.GIT_REF_SYMBOLIC
 	ReferenceOid                    = C.GIT_REF_OID
@@ -27,12 +28,19 @@ func newReferenceFromC(ptr *C.git_reference) *Reference {
 	return ref
 }
 
-func (v *Reference) SetSymbolicTarget(target string) (*Reference, error) {
+func (v *Reference) SetSymbolicTarget(target string, sig *Signature, msg string) (*Reference, error) {
 	var ptr *C.git_reference
+
 	ctarget := C.CString(target)
 	defer C.free(unsafe.Pointer(ctarget))
 
-	ret := C.git_reference_symbolic_set_target(&ptr, v.ptr, ctarget)
+	csig := sig.toC()
+	defer C.free(unsafe.Pointer(csig))
+
+	cmsg := C.CString(msg)
+	defer C.free(unsafe.Pointer(cmsg))
+
+	ret := C.git_reference_symbolic_set_target(&ptr, v.ptr, ctarget, csig, cmsg)
 	if ret < 0 {
 		return nil, LastError()
 	}
@@ -40,10 +48,16 @@ func (v *Reference) SetSymbolicTarget(target string) (*Reference, error) {
 	return newReferenceFromC(ptr), nil
 }
 
-func (v *Reference) SetTarget(target *Oid) (*Reference, error) {
+func (v *Reference) SetTarget(target *Oid, sig *Signature, msg string) (*Reference, error) {
 	var ptr *C.git_reference
 
-	ret := C.git_reference_set_target(&ptr, v.ptr, target.toC())
+	csig := sig.toC()
+	defer C.free(unsafe.Pointer(csig))
+
+	cmsg := C.CString(msg)
+	defer C.free(unsafe.Pointer(cmsg))
+
+	ret := C.git_reference_set_target(&ptr, v.ptr, target.toC(), csig, cmsg)
 	if ret < 0 {
 		return nil, LastError()
 	}

--- a/reference_test.go
+++ b/reference_test.go
@@ -14,7 +14,14 @@ func TestRefModification(t *testing.T) {
 
 	commitId, treeId := seedTestRepo(t, repo)
 
-	_, err := repo.CreateReference("refs/tags/tree", treeId, true)
+	loc, err := time.LoadLocation("Europe/Berlin")
+	checkFatal(t, err)
+	sig := &Signature{
+		Name:  "Rand Om Hacker",
+		Email: "random@hacker.com",
+		When:  time.Date(2013, 03, 06, 14, 30, 0, 0, loc),
+	}
+	_, err = repo.CreateReference("refs/tags/tree", treeId, true, sig, "testTreeTag")
 	checkFatal(t, err)
 
 	tag, err := repo.LookupReference("refs/tags/tree")
@@ -78,13 +85,13 @@ func TestIterator(t *testing.T) {
 	commitId, err := repo.CreateCommit("HEAD", sig, sig, message, tree)
 	checkFatal(t, err)
 
-	_, err = repo.CreateReference("refs/heads/one", commitId, true)
+	_, err = repo.CreateReference("refs/heads/one", commitId, true, sig, "headOne")
 	checkFatal(t, err)
 
-	_, err = repo.CreateReference("refs/heads/two", commitId, true)
+	_, err = repo.CreateReference("refs/heads/two", commitId, true, sig, "headTwo")
 	checkFatal(t, err)
 
-	_, err = repo.CreateReference("refs/heads/three", commitId, true)
+	_, err = repo.CreateReference("refs/heads/three", commitId, true, sig, "headThree")
 	checkFatal(t, err)
 
 	iter, err := repo.NewReferenceIterator()
@@ -108,7 +115,6 @@ func TestIterator(t *testing.T) {
 		t.Fatal("Iteration not over")
 	}
 
-
 	sort.Strings(list)
 	compareStringList(t, expected, list)
 
@@ -128,7 +134,6 @@ func TestIterator(t *testing.T) {
 	if count != 4 {
 		t.Fatalf("Wrong number of references returned %v", count)
 	}
-
 
 	// test the channel iteration
 	list = []string{}

--- a/submodule.go
+++ b/submodule.go
@@ -55,6 +55,14 @@ const (
 	SubmoduleStatusWdUntracked                     = C.GIT_SUBMODULE_STATUS_WD_UNTRACKED
 )
 
+type SubmoduleRecurse int
+
+const (
+	SubmoduleRecurseNo       SubmoduleRecurse = C.GIT_SUBMODULE_RECURSE_NO
+	SubmoduleRecurseYes                       = C.GIT_SUBMODULE_RECURSE_YES
+	SubmoduleRecurseOndemand                  = C.GIT_SUBMODULE_RECURSE_ONDEMAND
+)
+
 func SubmoduleStatusIsUnmodified(status int) bool {
 	o := SubmoduleStatus(status) & ^(SubmoduleStatusInHead | SubmoduleStatusInIndex |
 		SubmoduleStatusInConfig | SubmoduleStatusInWd)
@@ -212,8 +220,8 @@ func (sub *Submodule) FetchRecurseSubmodules() bool {
 	return true
 }
 
-func (sub *Submodule) SetFetchRecurseSubmodules(v bool) error {
-	ret := C.git_submodule_set_fetch_recurse_submodules(sub.ptr, cbool(v))
+func (sub *Submodule) SetFetchRecurseSubmodules(recurse SubmoduleRecurse) error {
+	ret := C.git_submodule_set_fetch_recurse_submodules(sub.ptr, C.git_submodule_recurse_t(recurse))
 	if ret < 0 {
 		return LastError()
 	}


### PR DESCRIPTION
Libgit2's development branch introduced breaking changes to git2go. This commit unbreaks the changes.

Additionally, ran `go fmt` on affected files.
