### PR TITLE
Add Is$Type methods to Reference.

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -122,6 +122,18 @@ func (v *Reference) Type() ReferenceType {
 	return ReferenceType(C.git_reference_type(v.ptr))
 }
 
+func (v *Reference) IsBranch() bool {
+	return C.git_reference_is_branch(v.ptr) == 1
+}
+
+func (v *Reference) IsRemote() bool {
+	return C.git_reference_is_remote(v.ptr) == 1
+}
+
+func (v *Reference) IsTag() bool {
+	return C.git_reference_is_tag(v.ptr) == 1
+}
+
 func (v *Reference) Free() {
 	runtime.SetFinalizer(v, nil)
 	C.git_reference_free(v.ptr)


### PR DESCRIPTION
This patch adds the following methods to Reference:

```
IsBranch() bool
IsRemote() bool
IsTag() bool
```

which correspond to the `git_reference_is_$type` functions in libgit2.
