### PR TITLE
fix chunk create return values

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -55,13 +55,13 @@ func blobChunkCb(buffer *C.char, maxLen C.size_t, payload unsafe.Pointer) int {
 	data := (*BlobCallbackData)(payload)
 	goBuf, err := data.Callback(int(maxLen))
 	if err == io.EOF {
-		return 1
+		return 0
 	} else if err != nil {
 		data.Error = err
 		return -1
 	}
-	C.memcpy(unsafe.Pointer(buffer), unsafe.Pointer(&goBuf), C.size_t(len(goBuf)))
-	return 0
+	C.memcpy(unsafe.Pointer(buffer), unsafe.Pointer(&goBuf[0]), C.size_t(len(goBuf)))
+	return len(goBuf)
 }
 
 func (repo *Repository) CreateBlobFromChunks(hintPath string, callback BlobChunkCallback) (*Oid, error) {


### PR DESCRIPTION
libgit2 docs look incorrect:
http://libgit2.github.com/libgit2/#HEAD/group/blob/git_blob_create_fromchunks

"When there is no more data to stream, callback should return 
1. This will prevent it from being invoked anymore."

Testing and a look at blob.c seems to confirm result should be 0 when there is no more data, -1 if error, and  otherwise length of data copied to buffer.
