### PR TITLE
Repository.CreateCommit: Allow empty refname for non-update commit

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -326,10 +326,12 @@ func (v *Repository) CreateCommit(
 
 	oid := new(Oid)
 
-	cref := C.CString(refname)
-	defer C.free(unsafe.Pointer(cref))
+	var cref *C.char
 	if refname == "" {
 		cref = nil
+	} else {
+		cref = C.CString(refname)
+		defer C.free(unsafe.Pointer(cref))
 	}
 
 	cmsg := C.CString(message)


### PR DESCRIPTION
[The documentation](https://libgit2.github.com/libgit2/#HEAD/group/commit/git_commit_create) implies that `refname` _can_ be NULL if you don't want to automatically udpate a ref. This is useful if you want to create a new root commit (without any parents, think a `gh-pages` branch). 

This commit enables users to use the empty string for `refname` to signal a non-updating commit.
