### PR TITLE
Export PatchFromBuffers function.

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -374,21 +374,8 @@ func diffNotifyCb(_diff_so_far unsafe.Pointer, delta_to_add *C.git_diff_delta, m
 	return 0
 }
 
-func (v *Repository) DiffTreeToTree(oldTree, newTree *Tree, opts *DiffOptions) (*Diff, error) {
-	var diffPtr *C.git_diff
-	var oldPtr, newPtr *C.git_tree
-
-	if oldTree != nil {
-		oldPtr = oldTree.cast_ptr
-	}
-
-	if newTree != nil {
-		newPtr = newTree.cast_ptr
-	}
-
+func diffOptionsToC(opts *DiffOptions) (copts *C.git_diff_options, notifyData *diffNotifyData) {
 	cpathspec := C.git_strarray{}
-	var copts *C.git_diff_options
-	var notifyData *diffNotifyData
 	if opts != nil {
 		notifyData = &diffNotifyData{
 			Callback: opts.NotifyCallback,
@@ -396,7 +383,6 @@ func (v *Repository) DiffTreeToTree(oldTree, newTree *Tree, opts *DiffOptions) (
 		if opts.Pathspec != nil {
 			cpathspec.count = C.size_t(len(opts.Pathspec))
 			cpathspec.strings = makeCStringsFromStrings(opts.Pathspec)
-			defer freeStrarray(&cpathspec)
 		}
 
 		copts = &C.git_diff_options{
@@ -415,6 +401,30 @@ func (v *Repository) DiffTreeToTree(oldTree, newTree *Tree, opts *DiffOptions) (
 			copts.notify_payload = unsafe.Pointer(notifyData)
 		}
 	}
+	return
+}
+
+func freeDiffOptions(copts *C.git_diff_options) {
+	if copts != nil {
+		cpathspec := copts.pathspec
+		freeStrarray(&cpathspec)
+	}
+}
+
+func (v *Repository) DiffTreeToTree(oldTree, newTree *Tree, opts *DiffOptions) (*Diff, error) {
+	var diffPtr *C.git_diff
+	var oldPtr, newPtr *C.git_tree
+
+	if oldTree != nil {
+		oldPtr = oldTree.cast_ptr
+	}
+
+	if newTree != nil {
+		newPtr = newTree.cast_ptr
+	}
+
+	copts, notifyData := diffOptionsToC(opts)
+	defer freeDiffOptions(copts)
 
 	ecode := C.git_diff_tree_to_tree(&diffPtr, v.ptr, oldPtr, newPtr, copts)
 	if ecode < 0 {
@@ -435,35 +445,8 @@ func (v *Repository) DiffTreeToWorkdir(oldTree *Tree, opts *DiffOptions) (*Diff,
 		oldPtr = oldTree.cast_ptr
 	}
 
-	cpathspec := C.git_strarray{}
-	var copts *C.git_diff_options
-	var notifyData *diffNotifyData
-	if opts != nil {
-		notifyData = &diffNotifyData{
-			Callback: opts.NotifyCallback,
-		}
-		if opts.Pathspec != nil {
-			cpathspec.count = C.size_t(len(opts.Pathspec))
-			cpathspec.strings = makeCStringsFromStrings(opts.Pathspec)
-			defer freeStrarray(&cpathspec)
-		}
-
-		copts = &C.git_diff_options{
-			version:           C.GIT_DIFF_OPTIONS_VERSION,
-			flags:             C.uint32_t(opts.Flags),
-			ignore_submodules: C.git_submodule_ignore_t(opts.IgnoreSubmodules),
-			pathspec:          cpathspec,
-			context_lines:     C.uint16_t(opts.ContextLines),
-			interhunk_lines:   C.uint16_t(opts.InterhunkLines),
-			id_abbrev:         C.uint16_t(opts.IdAbbrev),
-			max_size:          C.git_off_t(opts.MaxSize),
-		}
-
-		if opts.NotifyCallback != nil {
-			C._go_git_setup_diff_notify_callbacks(copts)
-			copts.notify_payload = unsafe.Pointer(notifyData)
-		}
-	}
+	copts, notifyData := diffOptionsToC(opts)
+	defer freeDiffOptions(copts)
 
 	ecode := C.git_diff_tree_to_workdir(&diffPtr, v.ptr, oldPtr, copts)
 	if ecode < 0 {
@@ -474,5 +457,4 @@ func (v *Repository) DiffTreeToWorkdir(oldTree *Tree, opts *DiffOptions) (*Diff,
 		return notifyData.Diff, nil
 	}
 	return newDiffFromC(diffPtr), nil
-
 }


### PR DESCRIPTION
Export PatchFromBuffers function and factor out diffOptionsToC function to remove
duplicated code in diff.go
