### PR TITLE
Diff: heed DiffOptions fields OldPrefix and NewPrefix

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -371,6 +371,8 @@ func DefaultDiffOptions() (DiffOptions, error) {
 		InterhunkLines:   uint32(opts.interhunk_lines),
 		IdAbbrev:         uint16(opts.id_abbrev),
 		MaxSize:          int(opts.max_size),
+		OldPrefix:        "a",
+		NewPrefix:        "b",
 	}, nil
 }
 
@@ -479,6 +481,8 @@ func diffOptionsToC(opts *DiffOptions) (copts *C.git_diff_options, notifyData *d
 			interhunk_lines:   C.uint32_t(opts.InterhunkLines),
 			id_abbrev:         C.uint16_t(opts.IdAbbrev),
 			max_size:          C.git_off_t(opts.MaxSize),
+			old_prefix:        C.CString(opts.OldPrefix),
+			new_prefix:        C.CString(opts.NewPrefix),
 		}
 
 		if opts.NotifyCallback != nil {
@@ -493,6 +497,8 @@ func freeDiffOptions(copts *C.git_diff_options) {
 	if copts != nil {
 		cpathspec := copts.pathspec
 		freeStrarray(&cpathspec)
+		C.free(unsafe.Pointer(copts.old_prefix))
+		C.free(unsafe.Pointer(copts.new_prefix))
 	}
 }
 


### PR DESCRIPTION
This PR makes diffing heed the OldPrefix and NewPrefix fields in
DiffOptions.

Before this patch, running the modified TestDiffTreeToTree fails:

```
--- FAIL: TestDiffTreeToTree-12 (0.02s)
    diff_test.go:150: Diff patch doesn't contain "x1/README" or "y1/README"

        diff --git a/README b/README
        index 257cc56..820734a 100644
        --- a/README
        +++ b/README
        @@ -1 +1 @@
        -foo
        +file changed

```

It passes with the changes to diff.go in this PR.
