### PR TITLE
Use a Go package to init OpenSSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ go:
   - 1.3
   - tip
 
+install:
+  - go get -d
+
 matrix:
   allow_failures:
     - go: tip

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ will compile libgit2 and run `go install` such that it's statically linked to th
 Paralellism and network operations
 ----------------------------------
 
-libgit2 uses OpenSSL and LibSSH2 for performing encrypted network connections. For now, git2go asks libgit2 to set locking for OpenSSL. This makes HTTPS connections thread-safe, but it is fragile and will likely stop doing it soon. This may also make SSH connections thread-safe if your copy of libssh2 is linked against OpenSSL. Check libgit2's `THREADSAFE.md` for more information.
+libgit2 uses OpenSSL and LibSSH2 for performing encrypted network connections. git2go uses the "github.com/spacemonkeygo/openssl" package to ensure a single-init of the locking using a common synchronization oint. This makes HTTPS connections thread-safe. This may also make SSH connections thread-safe if your copy of libssh2 is linked against OpenSSL. Check libgit2's `THREADSAFE.md` for more information.
 
 Running the tests
 -----------------

--- a/git.go
+++ b/git.go
@@ -14,6 +14,10 @@ import (
 	"unsafe"
 )
 
+// We import this in order to have Go-level synchronization about when
+// the OpenSSL locking should be happening
+import _ "github.com/spacemonkeygo/openssl"
+
 type ErrorClass int
 
 const (
@@ -94,13 +98,6 @@ var (
 
 func init() {
 	C.git_libgit2_init()
-
-	// This is not something we should be doing, as we may be
-	// stomping all over someone else's setup. The user should do
-	// this themselves or use some binding/wrapper which does it
-	// in such a way that they can be sure they're the only ones
-	// setting it up.
-	C.git_openssl_set_locking()
 }
 
 // Oid represents the id for a Git object.


### PR DESCRIPTION
This let us perform the synchronization at the Go level instead of
hoping nobody else has touched OpenSSL.

---

This would have to wait for spacemonkeygo/openssl#23 to make sure it keeps working on OSX.
