### PR TITLE
Add TargetDirectory field to Checkout options.

### DIFF
--- a/checkout.go
+++ b/checkout.go
@@ -69,6 +69,9 @@ func populateCheckoutOpts(ptr *C.git_checkout_options, opts *CheckoutOpts) *C.gi
 }
 
 func freeCheckoutOpts(ptr *C.git_checkout_options) {
+	if ptr == nil {
+		return
+	}
 	C.free(unsafe.Pointer(ptr.target_directory))
 }
 

--- a/checkout.go
+++ b/checkout.go
@@ -31,11 +31,12 @@ const (
 )
 
 type CheckoutOpts struct {
-	Strategy       CheckoutStrategy // Default will be a dry run
-	DisableFilters bool             // Don't apply filters like CRLF conversion
-	DirMode        os.FileMode      // Default is 0755
-	FileMode       os.FileMode      // Default is 0644 or 0755 as dictated by blob
-	FileOpenFlags  int              // Default is O_CREAT | O_TRUNC | O_WRONLY
+	Strategy        CheckoutStrategy // Default will be a dry run
+	DisableFilters  bool             // Don't apply filters like CRLF conversion
+	DirMode         os.FileMode      // Default is 0755
+	FileMode        os.FileMode      // Default is 0644 or 0755 as dictated by blob
+	FileOpenFlags   int              // Default is O_CREAT | O_TRUNC | O_WRONLY
+	TargetDirectory string           // Alternative checkout path to workdir
 }
 
 func (opts *CheckoutOpts) toC() *C.git_checkout_options {
@@ -60,7 +61,9 @@ func populateCheckoutOpts(ptr *C.git_checkout_options, opts *CheckoutOpts) *C.gi
 	ptr.disable_filters = cbool(opts.DisableFilters)
 	ptr.dir_mode = C.uint(opts.DirMode.Perm())
 	ptr.file_mode = C.uint(opts.FileMode.Perm())
-
+	if opts.TargetDirectory != "" {
+		ptr.target_directory = C.CString(opts.TargetDirectory)
+	}
 	return ptr
 }
 

--- a/clone.go
+++ b/clone.go
@@ -30,6 +30,7 @@ func Clone(url string, path string, options *CloneOptions) (*Repository, error) 
 
 	var copts C.git_clone_options
 	populateCloneOptions(&copts, options)
+	defer freeCheckoutOpts(&copts.checkout_opts)
 
 	if len(options.CheckoutBranch) != 0 {
 		copts.checkout_branch = C.CString(options.CheckoutBranch)

--- a/merge.go
+++ b/merge.go
@@ -145,6 +145,7 @@ func (r *Repository) Merge(theirHeads []*AnnotatedCommit, mergeOptions *MergeOpt
 
 	cMergeOpts := mergeOptions.toC()
 	cCheckoutOpts := checkoutOptions.toC()
+	defer freeCheckoutOpts(cCheckoutOpts)
 
 	gmerge_head_array := make([]*C.git_annotated_commit, len(theirHeads))
 	for i := 0; i < len(theirHeads); i++ {


### PR DESCRIPTION
TargetDirectory field indicates a alternative checkout path to workdir.