### PR TITLE
Submodule foreach fix

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -97,10 +97,10 @@ func (repo *Repository) LookupSubmodule(name string) (*Submodule, error) {
 type SubmoduleCbk func(sub *Submodule, name string) int
 
 //export SubmoduleVisitor
-func SubmoduleVisitor(csub unsafe.Pointer, name string, cfct unsafe.Pointer) int {
+func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, cfct unsafe.Pointer) C.int {
 	sub := &Submodule{(*C.git_submodule)(csub)}
 	fct := *(*SubmoduleCbk)(cfct)
-	return fct(sub, name)
+	return (C.int)(fct(sub, C.GoString(name)))
 }
 
 func (repo *Repository) ForeachSubmodule(cbk SubmoduleCbk) error {

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -1,0 +1,24 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestSubmoduleForeach(t *testing.T) {
+	repo := createTestRepo(t)
+	seedTestRepo(t, repo)
+
+	_, err := repo.AddSubmodule("http://example.org/submodule", "submodule", true)
+	checkFatal(t, err)
+
+	i := 0
+	err = repo.ForeachSubmodule(func(sub *Submodule, name string) int {
+		i++
+		return 0
+	})
+	checkFatal(t, err)
+
+	if i != 1 {
+		t.Fatalf("expected one submodule found but got %i", i)
+	}
+}


### PR DESCRIPTION
This pull request fixes a panic with repo.ForeachSubmodule caused by a wrong signature of a function that is being called from libgit2. The first commit introduces a failing test and the second commit fixes the issue.