### PR TITLE
Fix test to force diff prefixes.

### DIFF
--- a/patch_test.go
+++ b/patch_test.go
@@ -20,7 +20,11 @@ func TestPatch(t *testing.T) {
 	newTree, err := repo.LookupTree(newTreeId)
 	checkFatal(t, err)
 
-	diff, err := repo.DiffTreeToTree(originalTree, newTree, nil)
+	opts := &DiffOptions{
+		OldPrefix: "a",
+		NewPrefix: "b",
+	}
+	diff, err := repo.DiffTreeToTree(originalTree, newTree, opts)
 	checkFatal(t, err)
 
 	patch, err := diff.Patch(0)


### PR DESCRIPTION
When you have `diff.noprefix` or `diff.mnemonicprefix` configuration set to true globally, such as in ~/.gitconfig, `TestPatch` fails.

This Pull Request fixes this problem by setting OldPrefix and NewPrefix explicitly.