### PR TITLE
Add bindings for git_graph_* methods

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -1,0 +1,36 @@
+package git
+
+/*
+#include <git2.h>
+*/
+import "C"
+import (
+	"runtime"
+)
+
+func (repo *Repository) GraphDescendantOf(commit, ancestor *Oid) (bool, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	ret := C.git_graph_descendant_of(repo.ptr, commit.toC(), ancestor.toC())
+	if ret < 0 {
+		return false, MakeGitError(ret)
+	}
+
+	return (ret > 0), nil
+}
+
+func (repo *Repository) GraphAheadBehind(local, upstream *Oid) (ahead, behind int, err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var aheadT C.size_t
+	var behindT C.size_t
+
+	ret := C.git_graph_ahead_behind(&aheadT, &behindT, repo.ptr, local.toC(), upstream.toC())
+	if ret < 0 {
+		return 0, 0, MakeGitError(ret)
+	}
+
+	return int(aheadT), int(behindT), nil
+}

--- a/graph.go
+++ b/graph.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 )
 
-func (repo *Repository) GraphDescendantOf(commit, ancestor *Oid) (bool, error) {
+func (repo *Repository) DescendantOf(commit, ancestor *Oid) (bool, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -20,7 +20,7 @@ func (repo *Repository) GraphDescendantOf(commit, ancestor *Oid) (bool, error) {
 	return (ret > 0), nil
 }
 
-func (repo *Repository) GraphAheadBehind(local, upstream *Oid) (ahead, behind int, err error) {
+func (repo *Repository) AheadBehind(local, upstream *Oid) (ahead, behind int, err error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 


### PR DESCRIPTION
This adds support for `git_graph_ahead_behind` and `git_graph_descendant_of` respectively wrapped as `Repository.GraphAheadBehind` and `Repository.GraphDescendantOf`.