### PR TITLE
use git_signature_free (fix test crash on Windows)

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -37,7 +37,7 @@ func (v *Reference) SetSymbolicTarget(target string, sig *Signature, msg string)
 	defer runtime.UnlockOSThread()
 
 	csig := sig.toC()
-	defer C.free(unsafe.Pointer(csig))
+	defer C.git_signature_free(csig)
 
 	var cmsg *C.char
 	if msg == "" {
@@ -62,7 +62,7 @@ func (v *Reference) SetTarget(target *Oid, sig *Signature, msg string) (*Referen
 	defer runtime.UnlockOSThread()
 
 	csig := sig.toC()
-	defer C.free(unsafe.Pointer(csig))
+	defer C.git_signature_free(csig)
 
 	var cmsg *C.char
 	if msg == "" {
@@ -100,7 +100,7 @@ func (v *Reference) Rename(name string, force bool, sig *Signature, msg string) 
 	defer C.free(unsafe.Pointer(cname))
 
 	csig := sig.toC()
-	defer C.free(unsafe.Pointer(csig))
+	defer C.git_signature_free(csig)
 
 	var cmsg *C.char
 	if msg == "" {

--- a/remote.go
+++ b/remote.go
@@ -605,7 +605,7 @@ func (o *Remote) Fetch(refspecs []string, sig *Signature, msg string) error {
 	var csig *C.git_signature = nil
 	if sig != nil {
 		csig = sig.toC()
-		defer C.free(unsafe.Pointer(csig))
+		defer C.git_signature_free(csig)
 	}
 
 	var cmsg *C.char = nil
@@ -697,7 +697,7 @@ func (o *Remote) Push(refspecs []string, opts *PushOptions, sig *Signature, msg 
 	var csig *C.git_signature = nil
 	if sig != nil {
 		csig = sig.toC()
-		defer C.free(unsafe.Pointer(csig))
+		defer C.git_signature_free(csig)
 	}
 
 	var cmsg *C.char

--- a/repository.go
+++ b/repository.go
@@ -211,7 +211,7 @@ func (v *Repository) SetHead(refname string, sig *Signature, msg string) error {
 	defer C.free(unsafe.Pointer(cname))
 
 	csig := sig.toC()
-	defer C.free(unsafe.Pointer(csig))
+	defer C.git_signature_free(csig)
 
 	var cmsg *C.char
 	if msg != "" {
@@ -231,7 +231,7 @@ func (v *Repository) SetHead(refname string, sig *Signature, msg string) error {
 
 func (v *Repository) SetHeadDetached(id *Oid, sig *Signature, msg string) error {
 	csig := sig.toC()
-	defer C.free(unsafe.Pointer(csig))
+	defer C.git_signature_free(csig)
 
 	var cmsg *C.char
 	if msg != "" {
@@ -254,7 +254,7 @@ func (v *Repository) CreateReference(name string, id *Oid, force bool, sig *Sign
 	defer C.free(unsafe.Pointer(cname))
 
 	csig := sig.toC()
-	defer C.free(unsafe.Pointer(csig))
+	defer C.git_signature_free(csig)
 
 	var cmsg *C.char
 	if msg == "" {
@@ -285,7 +285,7 @@ func (v *Repository) CreateSymbolicReference(name, target string, force bool, si
 	defer C.free(unsafe.Pointer(ctarget))
 
 	csig := sig.toC()
-	defer C.free(unsafe.Pointer(csig))
+	defer C.git_signature_free(csig)
 
 	var cmsg *C.char
 	if msg == "" {


### PR DESCRIPTION
libgit2 0.22.1 compiled x64 RelWithDebug using Visual Studio 2013 combined with the v22 branch crashes when running the unit tests. I've traced this to the use of `C.free(unsafe.Pointer(csig))` in some places instead of `C.git_signature_free(csig)` as in other places. Switching to `git_signature_free` seems to fix this. I don't know why in some places `free` was used over `git_signature_free`.