### PR TITLE
Add support for libgit2's git_reset.

### DIFF
--- a/reset.go
+++ b/reset.go
@@ -1,0 +1,26 @@
+package git
+
+/*
+#include <git2.h>
+*/
+import "C"
+import "runtime"
+
+type ResetType int
+
+const (
+	ResetSoft  ResetType = C.GIT_RESET_SOFT
+	ResetMixed ResetType = C.GIT_RESET_MIXED
+	ResetHard  ResetType = C.GIT_RESET_HARD
+)
+
+func (r *Repository) ResetToCommit(commit *Commit, resetType ResetType, opts *CheckoutOpts) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	ret := C.git_reset(r.ptr, commit.gitObject.ptr, C.git_reset_t(resetType), opts.toC())
+
+	if ret < 0 {
+		return MakeGitError(ret)
+	}
+	return nil
+}

--- a/reset_test.go
+++ b/reset_test.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestResetToCommit(t *testing.T) {
+	repo := createTestRepo(t)
+	seedTestRepo(t, repo)
+	// create commit to reset to
+	commitId, _ := updateReadme(t, repo, "testing reset")
+	// create commit to reset from
+	nextCommitId, _ := updateReadme(t, repo, "will be reset")
+
+	// confirm that we wrote "will be reset" to the readme
+	newBytes, err := ioutil.ReadFile(pathInRepo(repo, "README"))
+	checkFatal(t, err)
+	if string(newBytes) != "will be reset" {
+		t.Fatalf("expected %s to equal 'will be reset'", string(newBytes))
+	}
+
+	// confirm that the head of the repo is the next commit id
+	head, err := repo.Head()
+	checkFatal(t, err)
+	if head.Target().String() != nextCommitId.String() {
+		t.Fatalf(
+			"expected to be at latest commit %s, but was %s",
+			nextCommitId.String(),
+			head.Target().String(),
+		)
+	}
+
+	commitToResetTo, err := repo.LookupCommit(commitId)
+	checkFatal(t, err)
+
+	repo.ResetToCommit(commitToResetTo, ResetHard, &CheckoutOpts{})
+
+	// check that the file now reads "testing reset" like it did before
+	bytes, err := ioutil.ReadFile(pathInRepo(repo, "README"))
+	checkFatal(t, err)
+	if string(bytes) != "testing reset" {
+		t.Fatalf("expected %s to equal 'testing reset'", string(bytes))
+	}
+}


### PR DESCRIPTION
Hey all, I'm not super experienced with go and C, but I'm working on something that requires git reset. This should solve https://github.com/libgit2/git2go/issues/107.

Feel free to let me know if anything looks wrong in either implementation or style! I based this off of the `next` branch because that is what I'm using, not sure how much work it would be to update it for `master`.

Adds a new method to *Repository called ResetToCommit as well as constants for
the three reset modes that libgit2 currently supports. This does not need to be
limited to Commit, we actually just need something with a gitObject, which blobs
and other Objects have, they will just require different methods. I only need
to be able to reset to commits, so that's all I'm implementing right now.

Also adds a test which updates the test repository README twice and then resets
to the first commit.