### PR TITLE
Avoid installing script binary to user's $GOPATH/bin.

### DIFF
--- a/script/check-MakeGitError-thread-lock.go
+++ b/script/check-MakeGitError-thread-lock.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package main
 
 import (


### PR DESCRIPTION
If I am not mistaken, the `script/check-MakeGitError-thread-lock.go` is only needed and used in one place:

https://github.com/libgit2/git2go/blob/a4d5118374607f107af8063797f62e6a9f7470aa/Makefile#L7

It is used in `go run script/check-MakeGitError-thread-lock.go`.

However, the `install` target of the same Makefile performs `go install ./...`:

https://github.com/libgit2/git2go/blob/a4d5118374607f107af8063797f62e6a9f7470aa/Makefile#L11

Which ends up installing a `script` binary into user's $GOPATH/bin.

Many people have $GOPATH/bin as part of their $PATH, and if I am correct that `script` is not needed in any other way except that one place where `go run script/check-MakeGitError-thread-lock.go` uses it, then it's better to avoid installing the `script` binary to user's $GOPATH/bin and polluting that (already crowded) namespace.

This PR fixes that. (If I am mistaken, feel free to close the PR.)