### PR TITLE
[WIP/RFC] Pointer indirection

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -265,7 +265,11 @@ func (diff *Diff) ForEach(cbFile DiffForEachFileCallback, detail DiffDetail) err
 	data := &diffForEachData{
 		FileCallback: cbFile,
 	}
-	ecode := C._go_git_diff_foreach(diff.ptr, 1, intHunks, intLines, unsafe.Pointer(data))
+
+	handle := pointerHandles.Track(data)
+	defer pointerHandles.Untrack(handle)
+
+	ecode := C._go_git_diff_foreach(diff.ptr, 1, intHunks, intLines, handle)
 	if ecode < 0 {
 		return data.Error
 	}
@@ -273,8 +277,12 @@ func (diff *Diff) ForEach(cbFile DiffForEachFileCallback, detail DiffDetail) err
 }
 
 //export diffForEachFileCb
-func diffForEachFileCb(delta *C.git_diff_delta, progress C.float, payload unsafe.Pointer) int {
-	data := (*diffForEachData)(payload)
+func diffForEachFileCb(delta *C.git_diff_delta, progress C.float, handle unsafe.Pointer) int {
+	payload := pointerHandles.Get(handle)
+	data, ok := payload.(*diffForEachData)
+	if !ok {
+		panic("could not retrieve data for handle")
+	}
 
 	data.HunkCallback = nil
 	if data.FileCallback != nil {
@@ -292,8 +300,12 @@ func diffForEachFileCb(delta *C.git_diff_delta, progress C.float, payload unsafe
 type DiffForEachHunkCallback func(DiffHunk) (DiffForEachLineCallback, error)
 
 //export diffForEachHunkCb
-func diffForEachHunkCb(delta *C.git_diff_delta, hunk *C.git_diff_hunk, payload unsafe.Pointer) int {
-	data := (*diffForEachData)(payload)
+func diffForEachHunkCb(delta *C.git_diff_delta, hunk *C.git_diff_hunk, handle unsafe.Pointer) int {
+	payload := pointerHandles.Get(handle)
+	data, ok := payload.(*diffForEachData)
+	if !ok {
+		panic("could not retrieve data for handle")
+	}
 
 	data.LineCallback = nil
 	if data.HunkCallback != nil {
@@ -311,9 +323,12 @@ func diffForEachHunkCb(delta *C.git_diff_delta, hunk *C.git_diff_hunk, payload u
 type DiffForEachLineCallback func(DiffLine) error
 
 //export diffForEachLineCb
-func diffForEachLineCb(delta *C.git_diff_delta, hunk *C.git_diff_hunk, line *C.git_diff_line, payload unsafe.Pointer) int {
-
-	data := (*diffForEachData)(payload)
+func diffForEachLineCb(delta *C.git_diff_delta, hunk *C.git_diff_hunk, line *C.git_diff_line, handle unsafe.Pointer) int {
+	payload := pointerHandles.Get(handle)
+	data, ok := payload.(*diffForEachData)
+	if !ok {
+		panic("could not retrieve data for handle")
+	}
 
 	err := data.LineCallback(diffLineFromC(delta, hunk, line))
 	if err != nil {
@@ -479,9 +494,15 @@ type diffNotifyData struct {
 }
 
 //export diffNotifyCb
-func diffNotifyCb(_diff_so_far unsafe.Pointer, delta_to_add *C.git_diff_delta, matched_pathspec *C.char, payload unsafe.Pointer) int {
+func diffNotifyCb(_diff_so_far unsafe.Pointer, delta_to_add *C.git_diff_delta, matched_pathspec *C.char, handle unsafe.Pointer) int {
 	diff_so_far := (*C.git_diff)(_diff_so_far)
-	data := (*diffNotifyData)(payload)
+
+	payload := pointerHandles.Get(handle)
+	data, ok := payload.(*diffNotifyData)
+	if !ok {
+		panic("could not retrieve data for handle")
+	}
+
 	if data != nil {
 		if data.Diff == nil {
 			data.Diff = newDiffFromC(diff_so_far)
@@ -507,6 +528,7 @@ func diffOptionsToC(opts *DiffOptions) (copts *C.git_diff_options, notifyData *d
 		notifyData = &diffNotifyData{
 			Callback: opts.NotifyCallback,
 		}
+
 		if opts.Pathspec != nil {
 			cpathspec.count = C.size_t(len(opts.Pathspec))
 			cpathspec.strings = makeCStringsFromStrings(opts.Pathspec)
@@ -527,7 +549,7 @@ func diffOptionsToC(opts *DiffOptions) (copts *C.git_diff_options, notifyData *d
 
 		if opts.NotifyCallback != nil {
 			C._go_git_setup_diff_notify_callbacks(copts)
-			copts.notify_payload = unsafe.Pointer(notifyData)
+			copts.notify_payload = pointerHandles.Track(notifyData)
 		}
 	}
 	return
@@ -539,6 +561,7 @@ func freeDiffOptions(copts *C.git_diff_options) {
 		freeStrarray(&cpathspec)
 		C.free(unsafe.Pointer(copts.old_prefix))
 		C.free(unsafe.Pointer(copts.new_prefix))
+		pointerHandles.Untrack(copts.notify_payload)
 	}
 }
 

--- a/diff.go
+++ b/diff.go
@@ -561,7 +561,9 @@ func freeDiffOptions(copts *C.git_diff_options) {
 		freeStrarray(&cpathspec)
 		C.free(unsafe.Pointer(copts.old_prefix))
 		C.free(unsafe.Pointer(copts.new_prefix))
-		pointerHandles.Untrack(copts.notify_payload)
+		if copts.notify_payload != nil {
+			pointerHandles.Untrack(copts.notify_payload)
+		}
 	}
 }
 

--- a/git.go
+++ b/git.go
@@ -93,7 +93,11 @@ var (
 	ErrInvalid = errors.New("Invalid state for operation")
 )
 
+var pointerHandles *HandleList
+
 func init() {
+	pointerHandles = NewHandleList()
+
 	C.git_libgit2_init()
 
 	// This is not something we should be doing, as we may be

--- a/handles.go
+++ b/handles.go
@@ -16,6 +16,7 @@ type HandleList struct {
 func NewHandleList() *HandleList {
 	return &HandleList{
 		handles: make([]interface{}, 5),
+		set:     make(map[uintptr]bool),
 	}
 }
 

--- a/handles.go
+++ b/handles.go
@@ -23,7 +23,7 @@ func NewHandleList() *HandleList {
 // findUnusedSlot finds the smallest-index empty space in our
 // list. You must only run this function while holding a write lock.
 func (v *HandleList) findUnusedSlot() uintptr {
-	for i := 0; i < len(v.handles); i++ {
+	for i := 1; i < len(v.handles); i++ {
 		isUsed := v.set[uintptr(i)]
 		if !isUsed {
 			return uintptr(i)

--- a/handles.go
+++ b/handles.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"sync"
 	"unsafe"
 )
@@ -72,7 +73,7 @@ func (v *HandleList) Get(handle unsafe.Pointer) interface{} {
 	v.RLock()
 
 	if _, ok := v.set[slot]; !ok {
-		panic("invalid pointer handle")
+		panic(fmt.Sprintf("invalid pointer handle: %p", handle))
 	}
 
 	ptr := v.handles[slot]

--- a/handles.go
+++ b/handles.go
@@ -1,0 +1,82 @@
+package git
+
+import (
+	"sync"
+	"unsafe"
+)
+
+type HandleList struct {
+	sync.RWMutex
+	// stores the Go pointers
+	handles []interface{}
+	// indicates which indices are in use
+	set map[uintptr]bool
+}
+
+func NewHandleList() *HandleList {
+	return &HandleList{
+		handles: make([]interface{}, 5),
+	}
+}
+
+// findUnusedSlot finds the smallest-index empty space in our
+// list. You must only run this function while holding a write lock.
+func (v *HandleList) findUnusedSlot() uintptr {
+	for i := 0; i < len(v.handles); i++ {
+		isUsed := v.set[uintptr(i)]
+		if !isUsed {
+			return uintptr(i)
+		}
+	}
+
+	// reaching here means we've run out of entries so append and
+	// return the new index, which is equal to the old length.
+	slot := len(v.handles)
+	v.handles = append(v.handles, nil)
+
+	return uintptr(slot)
+}
+
+// Track adds the given pointer to the list of pointers to track and
+// returns a pointer value which can be passed to C as an opaque
+// pointer.
+func (v *HandleList) Track(pointer interface{}) unsafe.Pointer {
+	v.Lock()
+
+	slot := v.findUnusedSlot()
+	v.handles[slot] = pointer
+	v.set[slot] = true
+
+	v.Unlock()
+
+	return unsafe.Pointer(slot)
+}
+
+// Untrack stops tracking the pointer given by the handle
+func (v *HandleList) Untrack(handle unsafe.Pointer) {
+	slot := uintptr(handle)
+
+	v.Lock()
+
+	v.handles[slot] = nil
+	delete(v.set, slot)
+
+	v.Unlock()
+}
+
+// Get retrieves the pointer from the given handle
+func (v *HandleList) Get(handle unsafe.Pointer) interface{} {
+	slot := uintptr(handle)
+
+	v.RLock()
+
+	if _, ok := v.set[slot]; !ok {
+		panic("invalid pointer handle")
+	}
+
+	ptr := v.handles[slot]
+
+	v.RUnlock()
+
+	return ptr
+}

--- a/index.go
+++ b/index.go
@@ -234,12 +234,10 @@ func (v *Index) RemoveAll(pathspecs []string, callback IndexMatchedPathCallback)
 
 //export indexMatchedPathCallback
 func indexMatchedPathCallback(cPath, cMatchedPathspec *C.char, payload unsafe.Pointer) int {
-	if payload == nil {
-		return 0
-	} else if callback, ok := pointerHandles.Get(payload).(IndexMatchedPathCallback); ok {
+	if callback, ok := pointerHandles.Get(payload).(IndexMatchedPathCallback); ok {
 		return callback(C.GoString(cPath), C.GoString(cMatchedPathspec))
 	} else {
-		return -1
+		panic("invalid matched path callback")
 	}
 }
 

--- a/index.go
+++ b/index.go
@@ -162,16 +162,17 @@ func (v *Index) AddAll(pathspecs []string, flags IndexAddOpts, callback IndexMat
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	var cb *IndexMatchedPathCallback
+	var handle unsafe.Pointer
 	if callback != nil {
-		cb = &callback
+		handle = pointerHandles.Track(callback)
+		defer pointerHandles.Untrack(handle)
 	}
 
 	ret := C._go_git_index_add_all(
 		v.ptr,
 		&cpathspecs,
 		C.uint(flags),
-		unsafe.Pointer(cb),
+		handle,
 	)
 	if ret < 0 {
 		return MakeGitError(ret)
@@ -188,15 +189,16 @@ func (v *Index) UpdateAll(pathspecs []string, callback IndexMatchedPathCallback)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	var cb *IndexMatchedPathCallback
+	var handle unsafe.Pointer
 	if callback != nil {
-		cb = &callback
+		handle = pointerHandles.Track(callback)
+		defer pointerHandles.Untrack(handle)
 	}
 
 	ret := C._go_git_index_update_all(
 		v.ptr,
 		&cpathspecs,
-		unsafe.Pointer(cb),
+		handle,
 	)
 	if ret < 0 {
 		return MakeGitError(ret)
@@ -213,15 +215,16 @@ func (v *Index) RemoveAll(pathspecs []string, callback IndexMatchedPathCallback)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	var cb *IndexMatchedPathCallback
+	var handle unsafe.Pointer
 	if callback != nil {
-		cb = &callback
+		handle = pointerHandles.Track(callback)
+		defer pointerHandles.Untrack(handle)
 	}
 
 	ret := C._go_git_index_remove_all(
 		v.ptr,
 		&cpathspecs,
-		unsafe.Pointer(cb),
+		handle,
 	)
 	if ret < 0 {
 		return MakeGitError(ret)
@@ -231,8 +234,13 @@ func (v *Index) RemoveAll(pathspecs []string, callback IndexMatchedPathCallback)
 
 //export indexMatchedPathCallback
 func indexMatchedPathCallback(cPath, cMatchedPathspec *C.char, payload unsafe.Pointer) int {
-	callback := (*IndexMatchedPathCallback)(payload)
-	return (*callback)(C.GoString(cPath), C.GoString(cMatchedPathspec))
+	if payload == nil {
+		return 0
+	} else if callback, ok := pointerHandles.Get(payload).(IndexMatchedPathCallback); ok {
+		return callback(C.GoString(cPath), C.GoString(cMatchedPathspec))
+	} else {
+		return -1
+	}
 }
 
 func (v *Index) RemoveByPath(path string) error {

--- a/odb_test.go
+++ b/odb_test.go
@@ -81,7 +81,7 @@ func TestOdbForeach(t *testing.T) {
 
 	checkFatal(t, err)
 	if count != expect {
-		t.Fatalf("Expected %v objects, got %v")
+		t.Fatalf("Expected %v objects, got %v", expect, count)
 	}
 
 	expect = 1

--- a/submodule.go
+++ b/submodule.go
@@ -97,17 +97,24 @@ func (repo *Repository) LookupSubmodule(name string) (*Submodule, error) {
 type SubmoduleCbk func(sub *Submodule, name string) int
 
 //export SubmoduleVisitor
-func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, cfct unsafe.Pointer) C.int {
+func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer) C.int {
 	sub := &Submodule{(*C.git_submodule)(csub)}
-	fct := *(*SubmoduleCbk)(cfct)
-	return (C.int)(fct(sub, C.GoString(name)))
+
+	if callback, ok := pointerHandles.Get(handle).(SubmoduleCbk); ok {
+		return (C.int)(callback(sub, C.GoString(name)))
+	} else {
+		return -1
+	}
 }
 
 func (repo *Repository) ForeachSubmodule(cbk SubmoduleCbk) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C._go_git_visit_submodule(repo.ptr, unsafe.Pointer(&cbk))
+	handle := pointerHandles.Track(cbk)
+	defer pointerHandles.Untrack(handle)
+
+	ret := C._go_git_visit_submodule(repo.ptr, handle)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}

--- a/submodule.go
+++ b/submodule.go
@@ -103,7 +103,7 @@ func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer) 
 	if callback, ok := pointerHandles.Get(handle).(SubmoduleCbk); ok {
 		return (C.int)(callback(sub, C.GoString(name)))
 	} else {
-		return -1
+		panic("invalid submodule visitor callback")
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -90,8 +90,8 @@ func (t Tree) EntryCount() uint64 {
 type TreeWalkCallback func(string, *TreeEntry) int
 
 //export CallbackGitTreeWalk
-func CallbackGitTreeWalk(_root unsafe.Pointer, _entry unsafe.Pointer, ptr unsafe.Pointer) C.int {
-	root := C.GoString((*C.char)(_root))
+func CallbackGitTreeWalk(_root *C.char, _entry unsafe.Pointer, ptr unsafe.Pointer) C.int {
+	root := C.GoString(_root)
 	entry := (*C.git_tree_entry)(_entry)
 
 	if callback, ok := pointerHandles.Get(ptr).(TreeWalkCallback); ok {

--- a/tree.go
+++ b/tree.go
@@ -97,7 +97,7 @@ func CallbackGitTreeWalk(_root unsafe.Pointer, _entry unsafe.Pointer, ptr unsafe
 	if callback, ok := pointerHandles.Get(ptr).(TreeWalkCallback); ok {
 		return C.int(callback(root, newTreeEntry(entry)))
 	} else {
-		return C.int(-1)
+		panic("invalid treewalk callback")
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -93,19 +93,25 @@ type TreeWalkCallback func(string, *TreeEntry) int
 func CallbackGitTreeWalk(_root unsafe.Pointer, _entry unsafe.Pointer, ptr unsafe.Pointer) C.int {
 	root := C.GoString((*C.char)(_root))
 	entry := (*C.git_tree_entry)(_entry)
-	callback := *(*TreeWalkCallback)(ptr)
 
-	return C.int(callback(root, newTreeEntry(entry)))
+	if callback, ok := pointerHandles.Get(ptr).(TreeWalkCallback); ok {
+		return C.int(callback(root, newTreeEntry(entry)))
+	} else {
+		return C.int(-1)
+	}
 }
 
 func (t Tree) Walk(callback TreeWalkCallback) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
+	ptr := pointerHandles.Track(callback)
+	defer pointerHandles.Untrack(ptr)
+
 	err := C._go_git_treewalk(
 		t.cast_ptr,
 		C.GIT_TREEWALK_PRE,
-		unsafe.Pointer(&callback),
+		ptr,
 	)
 
 	if err < 0 {


### PR DESCRIPTION
This pull request fixes issues with Go callbacks that are handed over to C functions. As of Go 1.4 it is not possible to hand over Go pointers into C code as the garbage collector is allowed to copy around the stack, causing pointers to become invalid (see golang/go#8310 and golang/go#10303 for more information).

@carlosmn proposed an interface HandleList for pointer indirection which provides a global map of data that is to be tracked. Instead of handing in pointers we now instead hand over an index that points to the corresponding entry in this map.

This PR adds the HandleList implemented by @carlosmn, fixes some issues with it and adjusts code that hands over Go pointers into C code to use handles instead. Still missing is the remote.go code, as I am running into some error there ('runtime: garbage collector found invalid heap pointer *(0xc208063cd0+0x18)=0x1 s=nil') that I've not been able to fix.

This PR also fixes #163.