### PR TITLE
tests: always clean up temporary repository dirs

### DIFF
--- a/blame_test.go
+++ b/blame_test.go
@@ -1,15 +1,13 @@
 package git
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
 
 func TestBlame(t *testing.T) {
 	repo := createTestRepo(t)
-	defer repo.Free()
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	commitId1, _ := seedTestRepo(t, repo)
 	commitId2, _ := updateReadme(t, repo, "foo\nbar\nbaz\n")

--- a/blob_test.go
+++ b/blob_test.go
@@ -1,13 +1,12 @@
 package git
 
 import (
-	"os"
 	"testing"
 )
 
 func TestCreateBlobFromBuffer(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	id, err := repo.CreateBlobFromBuffer(make([]byte, 0))
 	checkFatal(t, err)

--- a/branch_test.go
+++ b/branch_test.go
@@ -1,9 +1,13 @@
 package git
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestBranchIterator(t *testing.T) {
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	seedTestRepo(t, repo)
 
 	i, err := repo.NewBranchIterator(BranchLocal)
@@ -24,6 +28,8 @@ func TestBranchIterator(t *testing.T) {
 
 func TestBranchIteratorEach(t *testing.T) {
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	seedTestRepo(t, repo)
 
 	i, err := repo.NewBranchIterator(BranchLocal)

--- a/cherrypick_test.go
+++ b/cherrypick_test.go
@@ -34,6 +34,8 @@ func readReadme(t *testing.T, repo *Repository) string {
 
 func TestCherrypick(t *testing.T) {
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	c1, _ := seedTestRepo(t, repo)
 	c2, _ := updateReadme(t, repo, content)
 

--- a/clone_test.go
+++ b/clone_test.go
@@ -2,22 +2,21 @@ package git
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 )
 
 func TestClone(t *testing.T) {
 
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	seedTestRepo(t, repo)
 
 	path, err := ioutil.TempDir("", "git2go")
 	checkFatal(t, err)
 
-	_, err = Clone(repo.Path(), path, &CloneOptions{Bare: true})
-	defer os.RemoveAll(path)
+	repo2, err := Clone(repo.Path(), path, &CloneOptions{Bare: true})
+	defer cleanupTestRepo(t, repo2)
 
 	checkFatal(t, err)
 }

--- a/diff_test.go
+++ b/diff_test.go
@@ -2,15 +2,13 @@ package git
 
 import (
 	"errors"
-	"os"
 	"strings"
 	"testing"
 )
 
 func TestFindSimilar(t *testing.T) {
 	repo := createTestRepo(t)
-	defer repo.Free()
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	originalTree, newTree := createTestTrees(t, repo)
 
@@ -65,8 +63,7 @@ func TestFindSimilar(t *testing.T) {
 func TestDiffTreeToTree(t *testing.T) {
 
 	repo := createTestRepo(t)
-	defer repo.Free()
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	originalTree, newTree := createTestTrees(t, repo)
 

--- a/git_test.go
+++ b/git_test.go
@@ -2,10 +2,23 @@ package git
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 	"time"
 )
+
+func cleanupTestRepo(t *testing.T, r *Repository) {
+	var err error
+	if r.IsBare() {
+		err = os.RemoveAll(r.Path())
+	} else {
+		err = os.RemoveAll(r.Workdir())
+	}
+	checkFatal(t, err)
+
+	r.Free()
+}
 
 func createTestRepo(t *testing.T) *Repository {
 	// figure out where we can create the test repo

--- a/index_test.go
+++ b/index_test.go
@@ -2,14 +2,13 @@ package git
 
 import (
 	"io/ioutil"
-	"os"
 	"runtime"
 	"testing"
 )
 
 func TestCreateRepoAndStage(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	idx, err := repo.Index()
 	checkFatal(t, err)
@@ -25,10 +24,10 @@ func TestCreateRepoAndStage(t *testing.T) {
 
 func TestIndexWriteTreeTo(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	repo2 := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo2)
 
 	idx, err := repo.Index()
 	checkFatal(t, err)
@@ -44,7 +43,7 @@ func TestIndexWriteTreeTo(t *testing.T) {
 
 func TestIndexAddAndWriteTreeTo(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	odb, err := repo.Odb()
 	checkFatal(t, err)
@@ -74,7 +73,7 @@ func TestIndexAddAndWriteTreeTo(t *testing.T) {
 
 func TestIndexAddAllNoCallback(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	err := ioutil.WriteFile(repo.Workdir()+"/README", []byte("foo\n"), 0644)
 	checkFatal(t, err)
@@ -95,7 +94,7 @@ func TestIndexAddAllNoCallback(t *testing.T) {
 
 func TestIndexAddAllCallback(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	err := ioutil.WriteFile(repo.Workdir()+"/README", []byte("foo\n"), 0644)
 	checkFatal(t, err)

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,13 +1,13 @@
 package git
 
 import (
-	"os"
 	"testing"
 )
 
 func TestMergeWithSelf(t *testing.T) {
-
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	seedTestRepo(t, repo)
 
 	master, err := repo.LookupReference("refs/heads/master")
@@ -23,8 +23,9 @@ func TestMergeWithSelf(t *testing.T) {
 }
 
 func TestMergeAnalysisWithSelf(t *testing.T) {
-
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	seedTestRepo(t, repo)
 
 	master, err := repo.LookupReference("refs/heads/master")
@@ -44,7 +45,6 @@ func TestMergeAnalysisWithSelf(t *testing.T) {
 }
 
 func TestMergeSameFile(t *testing.T) {
-
 	file := MergeFileInput{
 		Path:     "test",
 		Mode:     33188,
@@ -68,8 +68,7 @@ func TestMergeSameFile(t *testing.T) {
 }
 func TestMergeTreesWithoutAncestor(t *testing.T) {
 	repo := createTestRepo(t)
-	defer repo.Free()
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	_, originalTreeId := seedTestRepo(t, repo)
 	originalTree, err := repo.LookupTree(originalTreeId)

--- a/note_test.go
+++ b/note_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -10,7 +9,7 @@ import (
 
 func TestCreateNote(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	commitId, _ := seedTestRepo(t, repo)
 
@@ -29,7 +28,8 @@ func TestCreateNote(t *testing.T) {
 
 func TestNoteIterator(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	seedTestRepo(t, repo)
 
 	notes := make([]*Note, 5)
@@ -64,7 +64,7 @@ func TestNoteIterator(t *testing.T) {
 
 func TestRemoveNote(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	commitId, _ := seedTestRepo(t, repo)
 
@@ -87,7 +87,7 @@ func TestRemoveNote(t *testing.T) {
 
 func TestDefaultNoteRef(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	ref, err := repo.DefaultNoteRef()
 	checkFatal(t, err)

--- a/object_test.go
+++ b/object_test.go
@@ -1,13 +1,13 @@
 package git
 
 import (
-	"os"
 	"testing"
 )
 
 func TestObjectPoymorphism(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	commitId, treeId := seedTestRepo(t, repo)
 
 	var obj Object
@@ -89,7 +89,8 @@ func checkOwner(t *testing.T, repo *Repository, obj Object) {
 
 func TestObjectOwner(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	commitId, treeId := seedTestRepo(t, repo)
 
 	commit, err := repo.LookupCommit(commitId)

--- a/odb_test.go
+++ b/odb_test.go
@@ -3,13 +3,13 @@ package git
 import (
 	"errors"
 	"io"
-	"os"
 	"testing"
 )
 
 func TestOdbStream(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	_, _ = seedTestRepo(t, repo)
 
 	odb, error := repo.Odb()
@@ -38,7 +38,8 @@ func TestOdbStream(t *testing.T) {
 func TestOdbHash(t *testing.T) {
 
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	_, _ = seedTestRepo(t, repo)
 
 	odb, error := repo.Odb()
@@ -64,7 +65,8 @@ Initial commit.`
 
 func TestOdbForeach(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	_, _ = seedTestRepo(t, repo)
 
 	odb, err := repo.Odb()

--- a/patch_test.go
+++ b/patch_test.go
@@ -7,8 +7,7 @@ import (
 
 func TestPatch(t *testing.T) {
 	repo := createTestRepo(t)
-	defer repo.Free()
-	//defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	_, originalTreeId := seedTestRepo(t, repo)
 	originalTree, err := repo.LookupTree(originalTreeId)

--- a/push_test.go
+++ b/push_test.go
@@ -1,15 +1,15 @@
 package git
 
 import (
-	"os"
 	"testing"
 )
 
 func TestRemotePush(t *testing.T) {
 	repo := createBareTestRepo(t)
-	defer os.RemoveAll(repo.Path())
+	defer cleanupTestRepo(t, repo)
+
 	localRepo := createTestRepo(t)
-	defer os.RemoveAll(localRepo.Workdir())
+	defer cleanupTestRepo(t, localRepo)
 
 	remote, err := localRepo.CreateRemote("test_push", repo.Path())
 	checkFatal(t, err)

--- a/reference_test.go
+++ b/reference_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"os"
 	"runtime"
 	"sort"
 	"testing"
@@ -10,7 +9,7 @@ import (
 
 func TestRefModification(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	commitId, treeId := seedTestRepo(t, repo)
 
@@ -62,7 +61,7 @@ func TestRefModification(t *testing.T) {
 
 func TestReferenceIterator(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	loc, err := time.LoadLocation("Europe/Berlin")
 	checkFatal(t, err)
@@ -140,7 +139,8 @@ func TestReferenceIterator(t *testing.T) {
 
 func TestReferenceOwner(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	commitId, _ := seedTestRepo(t, repo)
 
 	ref, err := repo.CreateReference("refs/heads/foo", commitId, true, nil, "")
@@ -158,7 +158,7 @@ func TestReferenceOwner(t *testing.T) {
 
 func TestUtil(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	commitId, _ := seedTestRepo(t, repo)
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -2,15 +2,13 @@ package git
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 )
 
 func TestRefspecs(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	remote, err := repo.CreateAnonymousRemote("git://foo/bar", "refs/heads/*:refs/heads/*")
 	checkFatal(t, err)
@@ -31,8 +29,7 @@ func TestRefspecs(t *testing.T) {
 
 func TestListRemotes(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	_, err := repo.CreateRemote("test", "git://foo/bar")
 
@@ -59,8 +56,7 @@ func assertHostname(cert *Certificate, valid bool, hostname string, t *testing.T
 
 func TestCertificateCheck(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	remote, err := repo.CreateRemote("origin", "https://github.com/libgit2/TestGitRepository")
 	checkFatal(t, err)
@@ -79,8 +75,7 @@ func TestCertificateCheck(t *testing.T) {
 
 func TestRemoteConnect(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	remote, err := repo.CreateRemote("origin", "https://github.com/libgit2/TestGitRepository")
 	checkFatal(t, err)
@@ -91,8 +86,7 @@ func TestRemoteConnect(t *testing.T) {
 
 func TestRemoteLs(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	remote, err := repo.CreateRemote("origin", "https://github.com/libgit2/TestGitRepository")
 	checkFatal(t, err)
@@ -110,8 +104,7 @@ func TestRemoteLs(t *testing.T) {
 
 func TestRemoteLsFiltering(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	remote, err := repo.CreateRemote("origin", "https://github.com/libgit2/TestGitRepository")
 	checkFatal(t, err)
@@ -137,8 +130,7 @@ func TestRemoteLsFiltering(t *testing.T) {
 
 func TestRemotePruneRefs(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	config, err := repo.Config()
 	checkFatal(t, err)
@@ -160,8 +152,7 @@ func TestRemotePruneRefs(t *testing.T) {
 
 func TestRemotePrune(t *testing.T) {
 	remoteRepo := createTestRepo(t)
-	defer os.RemoveAll(remoteRepo.Workdir())
-	defer remoteRepo.Free()
+	defer cleanupTestRepo(t, remoteRepo)
 
 	head, _ := seedTestRepo(t, remoteRepo)
 	commit, err := remoteRepo.LookupCommit(head)
@@ -178,8 +169,7 @@ func TestRemotePrune(t *testing.T) {
 	checkFatal(t, err)
 
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
-	defer repo.Free()
+	defer cleanupTestRepo(t, repo)
 
 	config, err := repo.Config()
 	checkFatal(t, err)

--- a/revparse_test.go
+++ b/revparse_test.go
@@ -1,13 +1,12 @@
 package git
 
 import (
-	"os"
 	"testing"
 )
 
 func TestRevparse(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	commitId, _ := seedTestRepo(t, repo)
 
@@ -19,7 +18,7 @@ func TestRevparse(t *testing.T) {
 
 func TestRevparseSingle(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	commitId, _ := seedTestRepo(t, repo)
 
@@ -31,7 +30,7 @@ func TestRevparseSingle(t *testing.T) {
 
 func TestRevparseExt(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	_, treeId := seedTestRepo(t, repo)
 

--- a/status_test.go
+++ b/status_test.go
@@ -2,15 +2,13 @@ package git
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 )
 
 func TestStatusFile(t *testing.T) {
 	repo := createTestRepo(t)
-	defer repo.Free()
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
 
 	state := repo.State()
 	if state != RepositoryStateNone {
@@ -30,10 +28,10 @@ func TestStatusFile(t *testing.T) {
 
 func TestStatusList(t *testing.T) {
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	// This commits the test repo README, so it doesn't show up in the status list and there's a head to compare to
 	seedTestRepo(t, repo)
-	defer repo.Free()
-	defer os.RemoveAll(repo.Workdir())
 
 	err := ioutil.WriteFile(path.Join(path.Dir(repo.Workdir()), "hello.txt"), []byte("Hello, World"), 0644)
 	checkFatal(t, err)

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -6,6 +6,8 @@ import (
 
 func TestSubmoduleForeach(t *testing.T) {
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	seedTestRepo(t, repo)
 
 	_, err := repo.AddSubmodule("http://example.org/submodule", "submodule", true)

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,14 +1,14 @@
 package git
 
 import (
-	"os"
 	"testing"
 	"time"
 )
 
 func TestCreateTag(t *testing.T) {
 	repo := createTestRepo(t)
-	defer os.RemoveAll(repo.Workdir())
+	defer cleanupTestRepo(t, repo)
+
 	commitId, _ := seedTestRepo(t, repo)
 
 	commit, err := repo.LookupCommit(commitId)


### PR DESCRIPTION
Some test repositories are not correctly removed after the tests
did run. Fix by introducing a function that is to be used for
cleaning up temporary test repositories.