### PR TITLE
Add error code matching GIT_EAUTH for authentication failures

### DIFF
--- a/git.go
+++ b/git.go
@@ -87,6 +87,8 @@ const (
 	ErrPassthrough ErrorCode = C.GIT_PASSTHROUGH
 	// Signals end of iteration with iterator
 	ErrIterOver ErrorCode = C.GIT_ITEROVER
+	// Authentication failed
+	ErrAuth ErrorCode = C.GIT_EAUTH
 )
 
 var (


### PR DESCRIPTION
My use case is a client which caches OAuth2 access tokens for authentication. When the access token expires, the client gets a new one using a refresh token.

Unfortunately, the only surefire way to know the access token has expired is to use it until authentication fails. So the client needs a way to know when authentication failed, and GIT_EAUTH seems to be the right error code to check for.