### PR TITLE
clone: do not free clone options' payload

### DIFF
--- a/clone_test.go
+++ b/clone_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 )
 
-func TestClone(t *testing.T) {
+const (
+	REMOTENAME = "testremote"
+)
 
+func TestClone(t *testing.T) {
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -19,4 +22,44 @@ func TestClone(t *testing.T) {
 	defer cleanupTestRepo(t, repo2)
 
 	checkFatal(t, err)
+}
+
+func TestCloneWithCallback(t *testing.T) {
+	testPayload := 0
+
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	seedTestRepo(t, repo)
+
+	path, err := ioutil.TempDir("", "git2go")
+	checkFatal(t, err)
+
+	opts := CloneOptions{
+		Bare: true,
+		RemoteCreateCallback: func(r Repository, name, url string) (*Remote, ErrorCode) {
+			testPayload += 1
+
+			remote, err := r.CreateRemote(REMOTENAME, url)
+			if err != nil {
+				return nil, ErrGeneric
+			}
+
+			return remote, ErrOk
+		},
+	}
+
+	repo2, err := Clone(repo.Path(), path, &opts)
+	defer cleanupTestRepo(t, repo2)
+
+	checkFatal(t, err)
+
+	if testPayload != 1 {
+		t.Fatal("Payload's value has not been changed")
+	}
+
+	remote, err := repo2.LookupRemote(REMOTENAME)
+	if err != nil || remote == nil {
+		t.Fatal("Remote was not created properly")
+	}
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -5,6 +5,11 @@
 
 typedef int (*gogit_submodule_cbk)(git_submodule *sm, const char *name, void *payload);
 
+void _go_git_populate_remote_cb(git_clone_options *opts)
+{
+	opts->remote_cb = (git_remote_create_cb)remoteCreateCallback;
+}
+
 int _go_git_visit_submodule(git_repository *repo, void *fct)
 {
 	  return git_submodule_foreach(repo, (gogit_submodule_cbk)&SubmoduleVisitor, fct);


### PR DESCRIPTION
The `void` pointer that is being passed when populating the clone
options' payload is currently being freed as soon as the
populating function returns. As the memory it points to is only
ever being accessed after the function returns this will cause
invalid memory access.

Fix this by removing the call to `free`. As we cannot know
what the caller is passing as content of the `void` pointer we
cannot take responsibility for `free`ing it. This has to be the
responsibility of the caller, instead.