### PR TITLE
Restore support for RemoteCallbacks in Remote.Push() [next]

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -72,12 +72,12 @@ type RemoteCallbacks struct {
 type FetchPrune uint
 
 const (
-	 // Use the setting from the configuration
+	// Use the setting from the configuration
 	FetchPruneUnspecified FetchPrune = C.GIT_FETCH_PRUNE_UNSPECIFIED
 	// Force pruning on
-	FetchPruneOn       FetchPrune = C.GIT_FETCH_PRUNE
+	FetchPruneOn FetchPrune = C.GIT_FETCH_PRUNE
 	// Force pruning off
-	FetchNoPrune       FetchPrune = C.GIT_FETCH_NO_PRUNE
+	FetchNoPrune FetchPrune = C.GIT_FETCH_NO_PRUNE
 )
 
 type DownloadTags uint
@@ -88,20 +88,20 @@ const (
 	DownloadTagsUnspecified DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED
 	// Ask the server for tags pointing to objects we're already
 	// downloading.
-	DownloadTagsAuto     DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_AUTO
+	DownloadTagsAuto DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_AUTO
 
 	// Don't ask for any tags beyond the refspecs.
-	DownloadTagsNone     DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_NONE
+	DownloadTagsNone DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_NONE
 
 	// Ask for the all the tags.
-	DownloadTagsAll      DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_ALL
+	DownloadTagsAll DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_ALL
 )
 
 type FetchOptions struct {
 	// Callbacks to use for this fetch operation
 	RemoteCallbacks RemoteCallbacks
 	// Whether to perform a prune after the fetch
-	Prune           FetchPrune
+	Prune FetchPrune
 	// Whether to write the results to FETCH_HEAD. Defaults to
 	// on. Leave this default in order to behave like git.
 	UpdateFetchhead bool
@@ -111,7 +111,7 @@ type FetchOptions struct {
 	// downloading all of them.
 	//
 	// The default is to auto-follow tags.
-	DownloadTags    DownloadTags
+	DownloadTags DownloadTags
 }
 
 type Remote struct {
@@ -153,6 +153,9 @@ type HostkeyCertificate struct {
 }
 
 type PushOptions struct {
+	// Callbacks to use for this push operation
+	RemoteCallbacks RemoteCallbacks
+
 	PbParallelism uint
 }
 
@@ -583,7 +586,7 @@ func (o *Remote) RefspecCount() uint {
 func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
 	C.git_fetch_init_options(options, C.GIT_FETCH_OPTIONS_VERSION)
 	if opts == nil {
-		return;
+		return
 	}
 	populateRemoteCallbacks(&options.callbacks, &opts.RemoteCallbacks)
 	options.prune = C.git_fetch_prune_t(opts.Prune)
@@ -591,11 +594,22 @@ func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
 	options.download_tags = C.git_remote_autotag_option_t(opts.DownloadTags)
 }
 
+func populatePushOptions(options *C.git_push_options, opts *PushOptions) {
+	C.git_push_init_options(options, C.GIT_PUSH_OPTIONS_VERSION)
+	if opts == nil {
+		return
+	}
+
+	options.pb_parallelism = C.uint(opts.PbParallelism)
+
+	populateRemoteCallbacks(&options.callbacks, &opts.RemoteCallbacks)
+}
+
 // Fetch performs a fetch operation. refspecs specifies which refspecs
 // to use for this fetch, use an empty list to use the refspecs from
 // the configuration; msg specifies what to use for the reflog
 // entries. Leave "" to use defaults.
-func (o *Remote) Fetch(refspecs []string, opts *FetchOptions,  msg string) error {
+func (o *Remote) Fetch(refspecs []string, opts *FetchOptions, msg string) error {
 	var cmsg *C.char = nil
 	if msg != "" {
 		cmsg = C.CString(msg)
@@ -608,7 +622,7 @@ func (o *Remote) Fetch(refspecs []string, opts *FetchOptions,  msg string) error
 	defer freeStrarray(&crefspecs)
 
 	var coptions C.git_fetch_options
-	populateFetchOptions(&coptions, opts);
+	populateFetchOptions(&coptions, opts)
 	defer untrackCalbacksPayload(&coptions.callbacks)
 
 	runtime.LockOSThread()
@@ -630,7 +644,7 @@ func (o *Remote) ConnectPush(callbacks *RemoteCallbacks) error {
 }
 
 func (o *Remote) Connect(direction ConnectDirection, callbacks *RemoteCallbacks) error {
-	var ccallbacks C.git_remote_callbacks;
+	var ccallbacks C.git_remote_callbacks
 	populateRemoteCallbacks(&ccallbacks, callbacks)
 
 	runtime.LockOSThread()
@@ -689,22 +703,19 @@ func (o *Remote) Ls(filterRefs ...string) ([]RemoteHead, error) {
 }
 
 func (o *Remote) Push(refspecs []string, opts *PushOptions) error {
-	var copts C.git_push_options
-	C.git_push_init_options(&copts, C.GIT_PUSH_OPTIONS_VERSION)
-	if opts != nil {
-		copts.pb_parallelism = C.uint(opts.PbParallelism)
-	}
-
 	crefspecs := C.git_strarray{}
 	crefspecs.count = C.size_t(len(refspecs))
 	crefspecs.strings = makeCStringsFromStrings(refspecs)
 	defer freeStrarray(&crefspecs)
 
+	var coptions C.git_push_options
+	populatePushOptions(&coptions, opts)
+	defer untrackCalbacksPayload(&coptions.callbacks)
+
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	defer untrackCalbacksPayload(&copts.callbacks)
 
-	ret := C.git_remote_push(o.ptr, &crefspecs, &copts)
+	ret := C.git_remote_push(o.ptr, &crefspecs, &coptions)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -716,7 +727,7 @@ func (o *Remote) PruneRefs() bool {
 }
 
 func (o *Remote) Prune(callbacks *RemoteCallbacks) error {
-	var ccallbacks C.git_remote_callbacks;
+	var ccallbacks C.git_remote_callbacks
 	populateRemoteCallbacks(&ccallbacks, callbacks)
 
 	runtime.LockOSThread()

--- a/remote.go
+++ b/remote.go
@@ -214,7 +214,9 @@ func credentialsCallback(_cred **C.git_cred, _url *C.char, _username_from_url *C
 	url := C.GoString(_url)
 	username_from_url := C.GoString(_username_from_url)
 	ret, cred := callbacks.CredentialsCallback(url, username_from_url, (CredType)(allowed_types))
-	*_cred = cred.ptr
+	if cred != nil {
+		*_cred = cred.ptr
+	}
 	return int(ret)
 }
 


### PR DESCRIPTION
The `next` branch dropped support for `RemoteCallbacks` in `Remote.Push()` while still being available for `Remote.Fetch()`, this PR adds them back.

Without them it's impossible to authenticate during a push, etc ...