### PR TITLE
Fix bug in Config LookupString

### DIFF
--- a/config.go
+++ b/config.go
@@ -115,18 +115,20 @@ func (c *Config) LookupInt64(name string) (int64, error) {
 }
 
 func (c *Config) LookupString(name string) (string, error) {
-	var ptr *C.char
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
+
+	valBuf := C.git_buf{}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if ret := C.git_config_get_string(&ptr, c.ptr, cname); ret < 0 {
+	if ret := C.git_config_get_string_buf(&valBuf, c.ptr, cname); ret < 0 {
 		return "", MakeGitError(ret)
 	}
+	defer C.git_buf_free(&valBuf)
 
-	return C.GoString(ptr), nil
+	return C.GoString(valBuf.ptr), nil
 }
 
 func (c *Config) LookupBool(name string) (bool, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -5,24 +5,23 @@ import (
 	"testing"
 )
 
+var tempConfig = "./temp.gitconfig"
+
 func setupConfig() (*Config, error) {
 	var (
 		c   *Config
 		err error
-		p   string
 	)
 
-	p, err = ConfigFindGlobal()
-	if err != nil {
-		return nil, err
-	}
-
-	c, err = OpenOndisk(nil, p)
+	c, err = OpenOndisk(nil, tempConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	c.SetString("foo.bar", "baz")
+	c.SetBool("foo.bool", true)
+	c.SetInt32("foo.int32", 32)
+	c.SetInt64("foo.int64", 64)
 
 	return c, err
 }
@@ -31,28 +30,66 @@ func cleanupConfig() {
 	os.Remove(tempConfig)
 }
 
-func TestConfigLookupString(t *testing.T) {
+type TestRunner func(*Config, *testing.T)
+
+var tests = []TestRunner{
+	// LookupString
+	func(c *Config, t *testing.T) {
+		val, err := c.LookupString("foo.bar")
+		if err != nil {
+			t.Errorf("Got LookupString error: '%v', expected none\n", err)
+		}
+		if val != "baz" {
+			t.Errorf("Got '%s' from LookupString, expected 'bar'\n", val)
+		}
+	},
+	// LookupBool
+	func(c *Config, t *testing.T) {
+		val, err := c.LookupBool("foo.bool")
+		if err != nil {
+			t.Errorf("Got LookupBool error: '%v', expected none\n", err)
+		}
+		if !val {
+			t.Errorf("Got %b from LookupBool, expected 'false'\n", val)
+		}
+	},
+	// LookupInt32
+	func(c *Config, t *testing.T) {
+		val, err := c.LookupInt32("foo.int32")
+		if err != nil {
+			t.Errorf("Got LookupInt32 error: '%v', expected none\n", err)
+		}
+		if val != 32 {
+			t.Errorf("Got %v, expected 32\n", val)
+		}
+	},
+	// LookupInt64
+	func(c *Config, t *testing.T) {
+		val, err := c.LookupInt64("foo.int64")
+		if err != nil {
+			t.Errorf("Got LookupInt64 error: '%v', expected none\n", err)
+		}
+		if val != 64 {
+			t.Errorf("Got %v, expected 64\n", val)
+		}
+	},
+}
+
+func TestConfigLookups(t *testing.T) {
 	var (
 		err error
-		val string
 		c   *Config
 	)
 
 	c, err = setupConfig()
 	defer cleanupConfig()
+
 	if err != nil {
 		t.Errorf("Setup error: '%v'. Expected none\n", err)
-		t.FailNow()
 	}
 	defer c.Free()
 
-	val, err = c.LookupString("foo.bar")
-	if err != nil {
-		t.Errorf("Got error: '%v', expected none\n", err)
-		t.FailNow()
-	}
-
-	if val != "baz" {
-		t.Errorf("Got '%s', expected 'bar'\n", val)
+	for _, test := range tests {
+		test(c, t)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,58 @@
+package git
+
+import (
+	"os"
+	"testing"
+)
+
+func setupConfig() (*Config, error) {
+	var (
+		c   *Config
+		err error
+		p   string
+	)
+
+	p, err = ConfigFindGlobal()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err = OpenOndisk(nil, p)
+	if err != nil {
+		return nil, err
+	}
+
+	c.SetString("foo.bar", "baz")
+
+	return c, err
+}
+
+func cleanupConfig() {
+	os.Remove(tempConfig)
+}
+
+func TestConfigLookupString(t *testing.T) {
+	var (
+		err error
+		val string
+		c   *Config
+	)
+
+	c, err = setupConfig()
+	defer cleanupConfig()
+	if err != nil {
+		t.Errorf("Setup error: '%v'. Expected none\n", err)
+		t.FailNow()
+	}
+	defer c.Free()
+
+	val, err = c.LookupString("foo.bar")
+	if err != nil {
+		t.Errorf("Got error: '%v', expected none\n", err)
+		t.FailNow()
+	}
+
+	if val != "baz" {
+		t.Errorf("Got '%s', expected 'bar'\n", val)
+	}
+}


### PR DESCRIPTION
A solution to `get_string called on a live config object` errors when attempting a string lookup on a config object.