### PR TITLE
Fix Fetch/Push memory allocation problems

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -623,14 +623,16 @@ func (o *Remote) Fetch(refspecs []string, opts *FetchOptions,  msg string) error
 	crefspecs.strings = makeCStringsFromStrings(refspecs)
 	defer freeStrarray(&crefspecs)
 
-	var coptions C.git_fetch_options
-	populateFetchOptions(&coptions, opts);
+	coptions := (*C.git_fetch_options)(C.calloc(1, C.size_t(unsafe.Sizeof(C.git_fetch_options{}))))
+	defer C.free(unsafe.Pointer(coptions))
+
+	populateFetchOptions(coptions, opts)
 	defer untrackCalbacksPayload(&coptions.callbacks)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_remote_fetch(o.ptr, &crefspecs, &coptions, cmsg)
+	ret := C.git_remote_fetch(o.ptr, &crefspecs, coptions, cmsg)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -710,14 +712,16 @@ func (o *Remote) Push(refspecs []string, opts *PushOptions) error {
 	crefspecs.strings = makeCStringsFromStrings(refspecs)
 	defer freeStrarray(&crefspecs)
 
-	var coptions C.git_push_options
-	populatePushOptions(&coptions, opts)
+	coptions := (*C.git_push_options)(C.calloc(1, C.size_t(unsafe.Sizeof(C.git_push_options{}))))
+	defer C.free(unsafe.Pointer(coptions))
+
+	populatePushOptions(coptions, opts)
 	defer untrackCalbacksPayload(&coptions.callbacks)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_remote_push(o.ptr, &crefspecs, &coptions)
+	ret := C.git_remote_push(o.ptr, &crefspecs, coptions)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}


### PR DESCRIPTION
The Fetch/Push operations didn't allocate the git_*_options structure
and this causes a memory problem in the libgit2 code. Following the
example of Clone operation, the Fetch/Push functions allocates the
options structure before calling the C.