### PR TITLE
Expose git_odb_read_header as Odb.ReadHeader.

### DIFF
--- a/odb.go
+++ b/odb.go
@@ -54,6 +54,21 @@ func (v *Odb) AddBackend(backend *OdbBackend, priority int) (err error) {
 	return nil
 }
 
+func (v *Odb) ReadHeader(oid *Oid) (uint64, ObjectType, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	
+	var sz C.size_t
+	var cotype C.git_otype 
+
+	ret := C.git_odb_read_header(&sz, &cotype, v.ptr, oid.toC())
+	if ret < 0 {
+		return 0, C.GIT_OBJ_BAD, MakeGitError(ret)
+	}
+
+	return uint64(sz), ObjectType(cotype), nil
+}
+	
 func (v *Odb) Exists(oid *Oid) bool {
 	ret := C.git_odb_exists(v.ptr, oid.toC())
 	return ret != 0

--- a/odb_test.go
+++ b/odb_test.go
@@ -6,6 +6,34 @@ import (
 	"testing"
 )
 
+func TestOdbReadHeader(t *testing.T) {
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	_, _ = seedTestRepo(t, repo)
+	odb, err := repo.Odb()
+	if err != nil {
+		t.Fatalf("Odb: %v", err)
+	}
+	data := []byte("hello")
+	id, err := odb.Write(data, ObjectBlob)
+	if err != nil {
+		t.Fatalf("odb.Write: %v", err)
+	}
+
+	sz, typ, err := odb.ReadHeader(id)
+	if err != nil {
+		t.Fatalf("ReadHeader: %v", err)
+	}
+	
+	if sz != uint64(len(data)) {
+		t.Errorf("ReadHeader got size %d, want %d", sz, len(data))
+	}
+	if typ != ObjectBlob {
+		t.Errorf("ReadHeader got object type %s", typ)
+	}
+}
+
 func TestOdbStream(t *testing.T) {
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)


### PR DESCRIPTION
hi, this exposes git_odb_read_header, which is much faster for discovering size for a given OID. 