### PR TITLE
Treebuilder signature

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -58,8 +58,8 @@ func (v *Repository) BlameFile(path string, opts *BlameOptions) (*Blame, error) 
 			version:              C.GIT_BLAME_OPTIONS_VERSION,
 			flags:                C.uint32_t(opts.Flags),
 			min_match_characters: C.uint16_t(opts.MinMatchCharacters),
-			min_line:             C.uint32_t(opts.MinLine),
-			max_line:             C.uint32_t(opts.MaxLine),
+			min_line:             C.size_t(opts.MinLine),
+			max_line:             C.size_t(opts.MaxLine),
 		}
 		if opts.NewestCommit != nil {
 			copts.newest_commit = *opts.NewestCommit.toC()
@@ -100,7 +100,7 @@ func (blame *Blame) HunkByIndex(index int) (BlameHunk, error) {
 }
 
 func (blame *Blame) HunkByLine(lineno int) (BlameHunk, error) {
-	ptr := C.git_blame_get_hunk_byline(blame.ptr, C.uint32_t(lineno))
+	ptr := C.git_blame_get_hunk_byline(blame.ptr, C.size_t(lineno))
 	if ptr == nil {
 		return BlameHunk{}, ErrInvalid
 	}

--- a/diff.go
+++ b/diff.go
@@ -550,7 +550,7 @@ func diffOptionsToC(opts *DiffOptions) (copts *C.git_diff_options, notifyData *d
 
 		if opts.NotifyCallback != nil {
 			C._go_git_setup_diff_notify_callbacks(copts)
-			copts.notify_payload = pointerHandles.Track(notifyData)
+			copts.payload = pointerHandles.Track(notifyData)
 		}
 	}
 	return
@@ -562,8 +562,8 @@ func freeDiffOptions(copts *C.git_diff_options) {
 		freeStrarray(&cpathspec)
 		C.free(unsafe.Pointer(copts.old_prefix))
 		C.free(unsafe.Pointer(copts.new_prefix))
-		if copts.notify_payload != nil {
-			pointerHandles.Untrack(copts.notify_payload)
+		if copts.payload != nil {
+			pointerHandles.Untrack(copts.payload)
 		}
 	}
 }

--- a/merge.go
+++ b/merge.go
@@ -81,12 +81,12 @@ func (r *Repository) AnnotatedCommitFromRef(ref *Reference) (*AnnotatedCommit, e
 type MergeTreeFlag int
 
 const (
-	MergeTreeFindRenames MergeTreeFlag = C.GIT_MERGE_TREE_FIND_RENAMES
+	MergeTreeFindRenames MergeTreeFlag = C.GIT_MERGE_FIND_RENAMES
 )
 
 type MergeOptions struct {
-	Version     uint
-	TreeFlags   MergeTreeFlag
+	Version   uint
+	TreeFlags MergeTreeFlag
 
 	RenameThreshold uint
 	TargetLimit     uint
@@ -98,7 +98,7 @@ type MergeOptions struct {
 func mergeOptionsFromC(opts *C.git_merge_options) MergeOptions {
 	return MergeOptions{
 		Version:         uint(opts.version),
-		TreeFlags:           MergeTreeFlag(opts.tree_flags),
+		TreeFlags:       MergeTreeFlag(opts.flags),
 		RenameThreshold: uint(opts.rename_threshold),
 		TargetLimit:     uint(opts.target_limit),
 		FileFavor:       MergeFileFavor(opts.file_favor),
@@ -124,7 +124,7 @@ func (mo *MergeOptions) toC() *C.git_merge_options {
 	}
 	return &C.git_merge_options{
 		version:          C.uint(mo.Version),
-		tree_flags:       C.git_merge_tree_flag_t(mo.TreeFlags),
+		flags:            C.git_merge_flag_t(mo.TreeFlags),
 		rename_threshold: C.uint(mo.RenameThreshold),
 		target_limit:     C.uint(mo.TargetLimit),
 		file_favor:       C.git_merge_file_favor_t(mo.FileFavor),
@@ -262,10 +262,10 @@ func (r *Repository) MergeBases(one, two *Oid) ([]*Oid, error) {
 	}
 
 	oids := make([]*Oid, coids.count)
-	hdr := reflect.SliceHeader {
+	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(coids.ids)),
-		Len: int(coids.count),
-		Cap: int(coids.count),
+		Len:  int(coids.count),
+		Cap:  int(coids.count),
 	}
 
 	goSlice := *(*[]C.git_oid)(unsafe.Pointer(&hdr))
@@ -367,7 +367,7 @@ func populateCMergeFileOptions(c *C.git_merge_file_options, options MergeFileOpt
 	c.our_label = C.CString(options.OurLabel)
 	c.their_label = C.CString(options.TheirLabel)
 	c.favor = C.git_merge_file_favor_t(options.Favor)
-	c.flags = C.uint(options.Flags)
+	c.flags = C.git_merge_file_flag_t(options.Flags)
 }
 
 func freeCMergeFileOptions(c *C.git_merge_file_options) {

--- a/remote.go
+++ b/remote.go
@@ -72,12 +72,12 @@ type RemoteCallbacks struct {
 type FetchPrune uint
 
 const (
-	 // Use the setting from the configuration
+	// Use the setting from the configuration
 	FetchPruneUnspecified FetchPrune = C.GIT_FETCH_PRUNE_UNSPECIFIED
 	// Force pruning on
-	FetchPruneOn       FetchPrune = C.GIT_FETCH_PRUNE
+	FetchPruneOn FetchPrune = C.GIT_FETCH_PRUNE
 	// Force pruning off
-	FetchNoPrune       FetchPrune = C.GIT_FETCH_NO_PRUNE
+	FetchNoPrune FetchPrune = C.GIT_FETCH_NO_PRUNE
 )
 
 type DownloadTags uint
@@ -88,20 +88,20 @@ const (
 	DownloadTagsUnspecified DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED
 	// Ask the server for tags pointing to objects we're already
 	// downloading.
-	DownloadTagsAuto     DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_AUTO
+	DownloadTagsAuto DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_AUTO
 
 	// Don't ask for any tags beyond the refspecs.
-	DownloadTagsNone     DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_NONE
+	DownloadTagsNone DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_NONE
 
 	// Ask for the all the tags.
-	DownloadTagsAll      DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_ALL
+	DownloadTagsAll DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_ALL
 )
 
 type FetchOptions struct {
 	// Callbacks to use for this fetch operation
 	RemoteCallbacks RemoteCallbacks
 	// Whether to perform a prune after the fetch
-	Prune           FetchPrune
+	Prune FetchPrune
 	// Whether to write the results to FETCH_HEAD. Defaults to
 	// on. Leave this default in order to behave like git.
 	UpdateFetchhead bool
@@ -111,7 +111,7 @@ type FetchOptions struct {
 	// downloading all of them.
 	//
 	// The default is to auto-follow tags.
-	DownloadTags    DownloadTags
+	DownloadTags DownloadTags
 }
 
 type Remote struct {
@@ -588,7 +588,7 @@ func (o *Remote) RefspecCount() uint {
 func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
 	C.git_fetch_init_options(options, C.GIT_FETCH_OPTIONS_VERSION)
 	if opts == nil {
-		return;
+		return
 	}
 	populateRemoteCallbacks(&options.callbacks, &opts.RemoteCallbacks)
 	options.prune = C.git_fetch_prune_t(opts.Prune)
@@ -611,7 +611,7 @@ func populatePushOptions(options *C.git_push_options, opts *PushOptions) {
 // to use for this fetch, use an empty list to use the refspecs from
 // the configuration; msg specifies what to use for the reflog
 // entries. Leave "" to use defaults.
-func (o *Remote) Fetch(refspecs []string, opts *FetchOptions,  msg string) error {
+func (o *Remote) Fetch(refspecs []string, opts *FetchOptions, msg string) error {
 	var cmsg *C.char = nil
 	if msg != "" {
 		cmsg = C.CString(msg)
@@ -648,13 +648,14 @@ func (o *Remote) ConnectPush(callbacks *RemoteCallbacks) error {
 }
 
 func (o *Remote) Connect(direction ConnectDirection, callbacks *RemoteCallbacks) error {
-	var ccallbacks C.git_remote_callbacks;
+	var ccallbacks C.git_remote_callbacks
+	var remoteHeaders C.git_strarray
 	populateRemoteCallbacks(&ccallbacks, callbacks)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if ret := C.git_remote_connect(o.ptr, C.git_direction(direction), &ccallbacks); ret != 0 {
+	if ret := C.git_remote_connect(o.ptr, C.git_direction(direction), &ccallbacks, &remoteHeaders); ret != 0 {
 		return MakeGitError(ret)
 	}
 	return nil
@@ -733,7 +734,7 @@ func (o *Remote) PruneRefs() bool {
 }
 
 func (o *Remote) Prune(callbacks *RemoteCallbacks) error {
-	var ccallbacks C.git_remote_callbacks;
+	var ccallbacks C.git_remote_callbacks
 	populateRemoteCallbacks(&ccallbacks, callbacks)
 
 	runtime.LockOSThread()

--- a/tree.go
+++ b/tree.go
@@ -149,7 +149,7 @@ func (v *TreeBuilder) Free() {
 	C.git_treebuilder_free(v.ptr)
 }
 
-func (v *TreeBuilder) Insert(filename string, id *Oid, filemode int) error {
+func (v *TreeBuilder) Insert(filename string, id *Oid, filemode Filemode) error {
 	cfilename := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfilename))
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -20,3 +20,44 @@ func TestTreeEntryById(t *testing.T) {
 		t.Fatalf("entry id %v was not found", id)
 	}
 }
+
+func TestTreeBuilderInsert(t *testing.T) {
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	subTree, err := repo.TreeBuilder()
+	if err != nil {
+		t.Fatalf("TreeBuilder: %v", err)
+	}
+	defer subTree.Free()
+
+	odb, err := repo.Odb()
+	if err != nil {
+		t.Fatalf("repo.Odb: %v", err)
+	}
+	blobId, err := odb.Write([]byte("hello"), ObjectBlob)
+	if err != nil {
+		t.Fatalf("odb.Write: %v", err)
+	}
+	if err = subTree.Insert("subfile", blobId, FilemodeBlobExecutable); err != nil {
+		t.Fatalf("TreeBuilder.Insert: %v", err)
+	}
+	treeID, err := subTree.Write()
+	if err != nil {
+		t.Fatalf("TreeBuilder.Write: %v", err)
+	}
+
+	tree, err := repo.LookupTree(treeID)
+	if err != nil {
+		t.Fatalf("LookupTree: %v", err)
+	}
+
+	entry, err := tree.EntryByPath("subfile")
+	if err != nil {
+		t.Fatalf("tree.EntryByPath(%q): %v", "subfile", err)
+	}
+
+	if !entry.Id.Equal(blobId) {
+		t.Fatalf("got oid %v, want %v", entry.Id, blobId)
+	}
+}


### PR DESCRIPTION
the updated types on the constants cause TreeBuilder methods to fail.