### PR TITLE
Satisfy the 1.6 pointer rules

### DIFF
--- a/handles.go
+++ b/handles.go
@@ -52,12 +52,12 @@ func (v *HandleList) Track(pointer interface{}) unsafe.Pointer {
 
 	v.Unlock()
 
-	return unsafe.Pointer(&slot)
+	return unsafe.Pointer(uintptr(slot))
 }
 
 // Untrack stops tracking the pointer given by the handle
 func (v *HandleList) Untrack(handle unsafe.Pointer) {
-	slot := *(*int)(handle)
+	slot := int(uintptr(handle))
 
 	v.Lock()
 
@@ -69,7 +69,7 @@ func (v *HandleList) Untrack(handle unsafe.Pointer) {
 
 // Get retrieves the pointer from the given handle
 func (v *HandleList) Get(handle unsafe.Pointer) interface{} {
-	slot := *(*int)(handle)
+	slot := int(uintptr(handle))
 
 	v.RLock()
 

--- a/odb.go
+++ b/odb.go
@@ -76,12 +76,13 @@ func (v *Odb) Exists(oid *Oid) bool {
 
 func (v *Odb) Write(data []byte, otype ObjectType) (oid *Oid, err error) {
 	oid = new(Oid)
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	cstr := C.CString(string(data))
+	defer C.free(unsafe.Pointer(cstr))
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_odb_write(oid.toC(), v.ptr, unsafe.Pointer(hdr.Data), C.size_t(hdr.Len), C.git_otype(otype))
+	ret := C.git_odb_write(oid.toC(), v.ptr, unsafe.Pointer(cstr), C.size_t(len(data)), C.git_otype(otype))
 
 	if ret < 0 {
 		return nil, MakeGitError(ret)

--- a/wrapper.c
+++ b/wrapper.c
@@ -141,4 +141,21 @@ int _go_git_tag_foreach(git_repository *repo, void *payload)
     return git_tag_foreach(repo, (git_tag_foreach_cb)&gitTagForeachCb, payload);
 }
 
+/*
+ * Wrap git_merge_file() such that we pass the content directly from
+ * Go into C. Without it, we would have to allocate C memory to
+ * satisfy the pointer rules
+ */
+int _go_git_merge_file_wrapper(git_merge_file_result *out, git_merge_file_input *ancestor,
+			       git_merge_file_input *ours, git_merge_file_input *theirs,
+			       const git_merge_file_options *opts, void *content_ancestor,
+			       void *content_ours, void *content_theirs)
+{
+	ancestor->ptr = content_ancestor;
+	ours->ptr = content_ours;
+	theirs->ptr = content_theirs;
+
+	return git_merge_file(out, ancestor, ours, theirs, opts);
+}
+
 /* EOF */


### PR DESCRIPTION
This is based off of #282 but avoids making a copy of buffers we use for merging just to satisfy the pointer checker, avoiding a potentially large allocation (thrice).