### PR TITLE
odb: Expose git_odb_object_type() as OdbObject.Type()

### DIFF
--- a/odb.go
+++ b/odb.go
@@ -226,6 +226,10 @@ func (object *OdbObject) Len() (len uint64) {
 	return uint64(C.git_odb_object_size(object.ptr))
 }
 
+func (object *OdbObject) Type() ObjectType {
+	return ObjectType(C.git_odb_object_type(object.ptr))
+}
+
 func (object *OdbObject) Data() (data []byte) {
 	var c_blob unsafe.Pointer = C.git_odb_object_data(object.ptr)
 	var blob []byte


### PR DESCRIPTION
It might be needed when one is writing `git cat-file --batch` equivalent
which has output format

    <sha1> SP <type> SP <size> LF
    <contents> LF