### PR TITLE
Fix: Error conversion issue

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -173,7 +173,7 @@ func (v *RevWalk) Iterate(fun RevWalkIterator) (err error) {
 			return nil
 		}
 		if err != nil {
-			if err.(GitError).Code == ErrIterOver {
+			if err.(*GitError).Code == ErrIterOver {
 				err = nil
 			}
 

--- a/walk.go
+++ b/walk.go
@@ -173,10 +173,6 @@ func (v *RevWalk) Iterate(fun RevWalkIterator) (err error) {
 			return nil
 		}
 		if err != nil {
-			if err.(*GitError).Code == ErrIterOver {
-				err = nil
-			}
-
 			return err
 		}
 


### PR DESCRIPTION
We were seeing an issue with conversion of errors, and it ends up an error was being converted to `GitError rather than `*GitError`.