### PR TITLE
Rebase wrapper

### DIFF
--- a/git.go
+++ b/git.go
@@ -50,6 +50,7 @@ const (
 	ErrClassFilter     ErrorClass = C.GITERR_FILTER
 	ErrClassRevert     ErrorClass = C.GITERR_REVERT
 	ErrClassCallback   ErrorClass = C.GITERR_CALLBACK
+	ErrClassRebase     ErrorClass = C.GITERR_REBASE
 )
 
 type ErrorCode int

--- a/rebase.go
+++ b/rebase.go
@@ -1,0 +1,152 @@
+package git
+
+/*
+#include <git2.h>
+*/
+import "C"
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+// RebaseOperationType is the type of rebase operation
+type RebaseOperationType uint
+
+const (
+	// RebaseOperationPick The given commit is to be cherry-picked.  The client should commit the changes and continue if there are no conflicts.
+	RebaseOperationPick RebaseOperationType = C.GIT_REBASE_OPERATION_PICK
+	// RebaseOperationEdit The given commit is to be cherry-picked, but the client should stop to allow the user to edit the changes before committing them.
+	RebaseOperationEdit RebaseOperationType = C.GIT_REBASE_OPERATION_EDIT
+	// RebaseOperationSquash The given commit is to be squashed into the previous commit.  The commit message will be merged with the previous message.
+	RebaseOperationSquash RebaseOperationType = C.GIT_REBASE_OPERATION_SQUASH
+	// RebaseOperationFixup No commit will be cherry-picked.  The client should run the given command and (if successful) continue.
+	RebaseOperationFixup RebaseOperationType = C.GIT_REBASE_OPERATION_FIXUP
+	// RebaseOperationExec No commit will be cherry-picked.  The client should run the given command and (if successful) continue.
+	RebaseOperationExec RebaseOperationType = C.GIT_REBASE_OPERATION_EXEC
+)
+
+// RebaseOperation describes a single instruction/operation to be performed during the rebase.
+type RebaseOperation struct {
+	Type RebaseOperationType
+	ID   *Oid
+	Exec string
+}
+
+func rebaseOperationFromC(c *C.git_rebase_operation) *RebaseOperation {
+	operation := &RebaseOperation{}
+	operation.Type = RebaseOperationType(c._type)
+	operation.ID = newOidFromC(&c.id)
+	operation.Exec = C.GoString(c.exec)
+
+	return operation
+}
+
+// RebaseOptions are used to tell the rebase machinery how to operate
+type RebaseOptions struct{}
+
+// Rebase object wrapper for C pointer
+type Rebase struct {
+	ptr *C.git_rebase
+}
+
+//RebaseInit initializes a rebase operation to rebase the changes in branch relative to upstream onto another branch.
+func (r *Repository) RebaseInit(branch *AnnotatedCommit, upstream *AnnotatedCommit, onto *AnnotatedCommit, opts *RebaseOptions) (*Rebase, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	//TODO : use real rebase_options
+	if opts != nil {
+		return nil, errors.New("RebaseOptions Not implemented yet")
+	}
+
+	if branch == nil {
+		branch = &AnnotatedCommit{ptr: nil}
+	}
+
+	if upstream == nil {
+		upstream = &AnnotatedCommit{ptr: nil}
+	}
+
+	if onto == nil {
+		onto = &AnnotatedCommit{ptr: nil}
+	}
+
+	var ptr *C.git_rebase
+	err := C.git_rebase_init(&ptr, r.ptr, branch.ptr, upstream.ptr, onto.ptr, nil)
+	if err < 0 {
+		return nil, MakeGitError(err)
+	}
+
+	return newRebaseFromC(ptr), nil
+}
+
+// Next performs the next rebase operation and returns the information about it.
+// If the operation is one that applies a patch (which is any operation except GIT_REBASE_OPERATION_EXEC)
+// then the patch will be applied and the index and working directory will be updated with the changes.
+// If there are conflicts, you will need to address those before committing the changes.
+func (rebase *Rebase) Next() (*RebaseOperation, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var ptr *C.git_rebase_operation
+	err := C.git_rebase_next(&ptr, rebase.ptr)
+	if err < 0 {
+		return nil, MakeGitError(err)
+	}
+
+	return rebaseOperationFromC(ptr), nil
+}
+
+// Commit commits the current patch.
+// You must have resolved any conflicts that were introduced during the patch application from the git_rebase_next invocation.
+func (rebase *Rebase) Commit(ID *Oid, author, committer *Signature, message string) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	authorSig, err := author.toC()
+	if err != nil {
+		return err
+	}
+	defer C.git_signature_free(authorSig)
+
+	committerSig, err := committer.toC()
+	if err != nil {
+		return err
+	}
+
+	cmsg := C.CString(message)
+	defer C.free(unsafe.Pointer(cmsg))
+
+	cerr := C.git_rebase_commit(ID.toC(), rebase.ptr, authorSig, committerSig, nil, cmsg)
+	if cerr < 0 {
+		return MakeGitError(cerr)
+	}
+
+	return nil
+}
+
+// Finish finishes a rebase that is currently in progress once all patches have been applied.
+func (rebase *Rebase) Finish() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	err := C.git_rebase_finish(rebase.ptr, nil)
+	if err < 0 {
+		return MakeGitError(err)
+	}
+
+	return nil
+}
+
+//Free frees the Rebase object and underlying git_rebase C pointer.
+func (rebase *Rebase) Free() {
+	runtime.SetFinalizer(rebase, nil)
+	C.git_reference_free(rebase.ptr)
+}
+
+func newRebaseFromC(ptr *C.git_rebase) *Rebase {
+	rebase := &Rebase{ptr: ptr}
+	runtime.SetFinalizer(rebase, (*Rebase).Free)
+	return rebase
+}

--- a/rebase.go
+++ b/rebase.go
@@ -84,10 +84,17 @@ func (ro *RebaseOptions) toC() *C.git_rebase_options {
 		version:           C.uint(ro.Version),
 		quiet:             C.int(ro.Quiet),
 		inmemory:          C.int(ro.InMemory),
-		rewrite_notes_ref: C.CString(ro.RewriteNotesRef),
+		rewrite_notes_ref: rewriteNotesRefToC(ro.RewriteNotesRef),
 		merge_options:     *ro.MergeOptions.toC(),
 		checkout_options:  *ro.CheckoutOptions.toC(),
 	}
+}
+
+func rewriteNotesRefToC(ref string) *C.char {
+	if ref == "" {
+		return nil
+	}
+	return C.CString(ref)
 }
 
 // Rebase object wrapper for C pointer

--- a/rebase.go
+++ b/rebase.go
@@ -139,6 +139,11 @@ func (rebase *Rebase) Finish() error {
 	return nil
 }
 
+// OperationCount gets the count of rebase operations that are to be applied.
+func (rebase *Rebase) OperationCount() uint {
+	return uint(C.git_rebase_operation_entrycount(rebase.ptr))
+}
+
 //Free frees the Rebase object and underlying git_rebase C pointer.
 func (rebase *Rebase) Free() {
 	runtime.SetFinalizer(rebase, nil)
@@ -150,3 +155,13 @@ func newRebaseFromC(ptr *C.git_rebase) *Rebase {
 	runtime.SetFinalizer(rebase, (*Rebase).Free)
 	return rebase
 }
+
+/* TODO -- Add last wrapper services and manage rebase_options
+
+int git_rebase_abort(git_rebase *rebase);
+int git_rebase_init_options(git_rebase_options *opts, unsigned int version);
+int git_rebase_open(git_rebase **out, git_repository *repo, const git_rebase_options *opts);
+git_rebase_operation * git_rebase_operation_byindex(git_rebase *rebase, size_t idx);
+size_t git_rebase_operation_current(git_rebase *rebase);
+
+*/

--- a/rebase.go
+++ b/rebase.go
@@ -171,7 +171,7 @@ func (rebase *Rebase) Abort() error {
 //Free frees the Rebase object and underlying git_rebase C pointer.
 func (rebase *Rebase) Free() {
 	runtime.SetFinalizer(rebase, nil)
-	C.git_reference_free(rebase.ptr)
+	C.git_rebase_free(rebase.ptr)
 }
 
 func newRebaseFromC(ptr *C.git_rebase) *Rebase {

--- a/rebase.go
+++ b/rebase.go
@@ -50,6 +50,15 @@ type Rebase struct {
 	ptr *C.git_rebase
 }
 
+// Abort aborts a rebase that is currently in progress, resetting the repository and working directory to their state before rebase began.
+func (rebase *Rebase) Abort() error {
+	err := C.git_rebase_abort(rebase.ptr)
+	if err < 0 {
+		return MakeGitError(err)
+	}
+	return nil
+}
+
 //RebaseInit initializes a rebase operation to rebase the changes in branch relative to upstream onto another branch.
 func (r *Repository) RebaseInit(branch *AnnotatedCommit, upstream *AnnotatedCommit, onto *AnnotatedCommit, opts *RebaseOptions) (*Rebase, error) {
 	runtime.LockOSThread()
@@ -158,7 +167,6 @@ func newRebaseFromC(ptr *C.git_rebase) *Rebase {
 
 /* TODO -- Add last wrapper services and manage rebase_options
 
-int git_rebase_abort(git_rebase *rebase);
 int git_rebase_init_options(git_rebase_options *opts, unsigned int version);
 int git_rebase_open(git_rebase **out, git_repository *repo, const git_rebase_options *opts);
 git_rebase_operation * git_rebase_operation_byindex(git_rebase *rebase, size_t idx);

--- a/rebase.go
+++ b/rebase.go
@@ -81,6 +81,25 @@ func (r *Repository) RebaseInit(branch *AnnotatedCommit, upstream *AnnotatedComm
 	return newRebaseFromC(ptr), nil
 }
 
+//RebaseOpen opens an existing rebase that was previously started by either an invocation of git_rebase_init or by another client.
+func (r *Repository) RebaseOpen(opts *RebaseOptions) (*Rebase, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	//TODO : use real rebase_options
+	if opts != nil {
+		return nil, errors.New("RebaseOptions Not implemented yet, use nil for default opts")
+	}
+
+	var ptr *C.git_rebase
+	err := C.git_rebase_open(&ptr, r.ptr, nil)
+	if err < 0 {
+		return nil, MakeGitError(err)
+	}
+
+	return newRebaseFromC(ptr), nil
+}
+
 // OperationAt gets the rebase operation specified by the given index.
 func (rebase *Rebase) OperationAt(index uint) *RebaseOperation {
 	operation := C.git_rebase_operation_byindex(rebase.ptr, C.size_t(index))
@@ -183,6 +202,5 @@ func newRebaseFromC(ptr *C.git_rebase) *Rebase {
 /* TODO -- Add last wrapper services and manage rebase_options
 
 int git_rebase_init_options(git_rebase_options *opts, unsigned int version);
-int git_rebase_open(git_rebase **out, git_repository *repo, const git_rebase_options *opts);
 
 */

--- a/rebase.go
+++ b/rebase.go
@@ -145,16 +145,21 @@ func (r *Repository) OpenRebase(opts *RebaseOptions) (*Rebase, error) {
 // OperationAt gets the rebase operation specified by the given index.
 func (rebase *Rebase) OperationAt(index uint) *RebaseOperation {
 	operation := C.git_rebase_operation_byindex(rebase.ptr, C.size_t(index))
+	
 	return newRebaseOperationFromC(operation)
 }
 
 // CurrentOperationIndex gets the index of the rebase operation that is currently being applied.
 // Returns an error if no rebase operation is currently applied.
 func (rebase *Rebase) CurrentOperationIndex() (uint, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	operationIndex := int(C.git_rebase_operation_current(rebase.ptr))
 	if operationIndex == C.GIT_REBASE_NO_OPERATION {
 		return 0, MakeGitError(C.GIT_REBASE_NO_OPERATION)
 	}
+
 	return uint(operationIndex), nil
 }
 

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -9,29 +9,6 @@ import (
 
 // Tests
 
-func TestDefaultRebaseOptions(t *testing.T) {
-	opts, err := DefaultRebaseOptions()
-	checkFatal(t, err)
-
-	if opts.Version != 1 {
-		t.Error("Expected opts Version to equal 1, got ", opts.Version)
-	}
-	if opts.Quiet != 0 {
-		t.Error("Expected opts Quiet to equal 1, got ", opts.Quiet)
-	}
-	if opts.InMemory != 0 {
-		t.Error("Expected opts InMemory to equal 1, got ", opts.InMemory)
-	}
-	if opts.RewriteNotesRef != "" {
-		t.Error("Expected opts RewriteNotesRef to equal 1, got ", opts.RewriteNotesRef)
-	}
-
-	copts := opts.toC()
-	if copts == nil {
-		t.Error("Copts should not be nil")
-	}
-}
-
 func TestRebaseAbort(t *testing.T) {
 	// TEST DATA
 

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -1,0 +1,167 @@
+package git
+
+import (
+	"testing"
+	"time"
+)
+
+func createBranch(repo *Repository, branch string) error {
+	head, err := repo.Head()
+	if err != nil {
+		return err
+	}
+	commit, err := repo.LookupCommit(head.Target())
+	if err != nil {
+		return err
+	}
+	_, err = repo.CreateBranch(branch, commit, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func signature() *Signature {
+	return &Signature{
+		Name:  "Emile",
+		Email: "emile@emile.com",
+		When:  time.Now(),
+	}
+}
+
+func commitSomething(repo *Repository, something string) (*Oid, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return nil, err
+	}
+
+	headCommit, err := repo.LookupCommit(head.Target())
+	if err != nil {
+		return nil, err
+	}
+
+	index, err := NewIndex()
+	if err != nil {
+		return nil, err
+	}
+	defer index.Free()
+
+	blobOID, err := repo.CreateBlobFromBuffer([]byte("fou"))
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &IndexEntry{
+		Mode: FilemodeBlob,
+		Id:   blobOID,
+		Path: something,
+	}
+
+	if err := index.Add(entry); err != nil {
+		return nil, err
+	}
+
+	newTreeOID, err := index.WriteTreeTo(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	newTree, err := repo.LookupTree(newTreeOID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	commit, err := repo.CreateCommit("HEAD", signature(), signature(), "Test rebase onto, Baby! "+something, newTree, headCommit)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &CheckoutOpts{
+		Strategy: CheckoutRemoveUntracked | CheckoutForce,
+	}
+	err = repo.CheckoutIndex(index, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return commit, nil
+}
+
+func entryExists(repo *Repository, file string) bool {
+	head, err := repo.Head()
+	if err != nil {
+		return false
+	}
+	headCommit, err := repo.LookupCommit(head.Target())
+	if err != nil {
+		return false
+	}
+	headTree, err := headCommit.Tree()
+	if err != nil {
+		return false
+	}
+	_, err = headTree.EntryByPath(file)
+
+	return err == nil
+}
+
+func TestRebaseOnto(t *testing.T) {
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	fileInMaster := "something"
+	fileInEmile := "something else"
+
+	// Seed master
+	seedTestRepo(t, repo)
+
+	// Create a new branch from master
+	err := createBranch(repo, "emile")
+	checkFatal(t, err)
+
+	// Create a commit in master
+	_, err = commitSomething(repo, fileInMaster)
+	checkFatal(t, err)
+
+	// Switch to this emile
+	err = repo.SetHead("refs/heads/emile")
+	checkFatal(t, err)
+
+	// Check master commit is not in emile branch
+	if entryExists(repo, fileInMaster) {
+		t.Fatal("something entry should not exist in emile branch")
+	}
+
+	// Create a commit in emile
+	_, err = commitSomething(repo, fileInEmile)
+	checkFatal(t, err)
+
+	// Rebase onto master
+	master, err := repo.LookupBranch("master", BranchLocal)
+	branch, err := repo.AnnotatedCommitFromRef(master.Reference)
+	checkFatal(t, err)
+
+	rebase, err := repo.RebaseInit(nil, nil, branch, nil)
+	checkFatal(t, err)
+	defer rebase.Free()
+
+	operation, err := rebase.Next()
+	checkFatal(t, err)
+
+	commit, err := repo.LookupCommit(operation.ID)
+	checkFatal(t, err)
+
+	err = rebase.Commit(operation.ID, signature(), signature(), commit.Message())
+	checkFatal(t, err)
+
+	rebase.Finish()
+
+	// Check master commit is now also in emile branch
+	if !entryExists(repo, fileInMaster) {
+		t.Fatal("something entry should now exist in emile branch")
+	}
+}

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -143,6 +143,12 @@ func TestRebaseNoConflicts(t *testing.T) {
 	err = rebase.Finish()
 	checkFatal(t, err)
 
+	// Check no more rebase is in progress
+	oRebase, err = repo.RebaseOpen(nil)
+	if err == nil {
+		t.Fatal("Did not expect to find a rebase in progress")
+	}
+
 	// Check history is in correct order
 	actualHistory, err := commitMsgsList(repo)
 	checkFatal(t, err)

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -87,8 +87,14 @@ func TestRebaseNoConflicts(t *testing.T) {
 	defer cleanupTestRepo(t, repo)
 	seedTestRepo(t, repo)
 
+	// Try to open existing rebase
+	oRebase, err := repo.RebaseOpen(nil)
+	if err == nil {
+		t.Fatal("Did not expect to find a rebase in progress")
+	}
+
 	// Setup a repo with 2 branches and a different tree
-	err := setupRepoForRebase(repo, masterCommit, branchName)
+	err = setupRepoForRebase(repo, masterCommit, branchName)
 	checkFatal(t, err)
 
 	// Create several commits in emile
@@ -101,6 +107,14 @@ func TestRebaseNoConflicts(t *testing.T) {
 	rebase, err := performRebaseOnto(repo, "master")
 	checkFatal(t, err)
 	defer rebase.Free()
+
+	// Open existing rebase
+	oRebase, err = repo.RebaseOpen(nil)
+	checkFatal(t, err)
+	defer oRebase.Free()
+	if oRebase == nil {
+		t.Fatal("Expected to find an existing rebase in progress")
+	}
 
 	// Finish the rebase properly
 	err = rebase.Finish()

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -9,6 +9,29 @@ import (
 
 // Tests
 
+func TestDefaultRebaseOptions(t *testing.T) {
+	opts, err := DefaultRebaseOptions()
+	checkFatal(t, err)
+
+	if opts.Version != 1 {
+		t.Error("Expected opts Version to equal 1, got ", opts.Version)
+	}
+	if opts.Quiet != 0 {
+		t.Error("Expected opts Quiet to equal 1, got ", opts.Quiet)
+	}
+	if opts.InMemory != 0 {
+		t.Error("Expected opts InMemory to equal 1, got ", opts.InMemory)
+	}
+	if opts.RewriteNotesRef != "" {
+		t.Error("Expected opts RewriteNotesRef to equal 1, got ", opts.RewriteNotesRef)
+	}
+
+	copts := opts.toC()
+	if copts == nil {
+		t.Error("Copts should not be nil")
+	}
+}
+
 func TestRebaseAbort(t *testing.T) {
 	// TEST DATA
 


### PR DESCRIPTION
Hello,

I needed `rebase` services to be wrapped in `git2go` so I propose this PR.
Should I propose it on `next` branch instead of `master` ?

There's still some work though : 
- test what happens when a conflict arise during the rebase chain
- manage `git_rebase_options` and wrap `git_rebase_init_options(...)`
- wrap `git_rebase_open(...)`

I'll probably do the test for merge conflicts as I will need it quite soon.
Other services are of no interest for me at the moment, let me know if you'd like them wrapped as I'm into the work. Shouldn't be too long.

Let me know what you think. Cheers.
