### PR TITLE
Run the tests in parallel

### DIFF
--- a/blame_test.go
+++ b/blame_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestBlame(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/blob_test.go
+++ b/blob_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestCreateBlobFromBuffer(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/branch_test.go
+++ b/branch_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestBranchIterator(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -27,6 +28,7 @@ func TestBranchIterator(t *testing.T) {
 }
 
 func TestBranchIteratorEach(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/cherrypick_test.go
+++ b/cherrypick_test.go
@@ -33,6 +33,7 @@ func readReadme(t *testing.T, repo *Repository) string {
 }
 
 func TestCherrypick(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/clone_test.go
+++ b/clone_test.go
@@ -10,6 +10,7 @@ const (
 )
 
 func TestClone(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -35,6 +36,7 @@ func TestClone(t *testing.T) {
 }
 
 func TestCloneWithCallback(t *testing.T) {
+	t.Parallel()
 	testPayload := 0
 
 	repo := createTestRepo(t)

--- a/config_test.go
+++ b/config_test.go
@@ -88,6 +88,7 @@ var tests = []TestRunner{
 }
 
 func TestConfigLookups(t *testing.T) {
+	t.Parallel()
 	var (
 		err error
 		c   *Config

--- a/describe_test.go
+++ b/describe_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestDescribeCommit(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestFindSimilar(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -61,7 +62,7 @@ func TestFindSimilar(t *testing.T) {
 }
 
 func TestDiffTreeToTree(t *testing.T) {
-
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -189,6 +190,7 @@ func createTestTrees(t *testing.T, repo *Repository) (originalTree *Tree, newTre
 }
 
 func TestDiffBlobs(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/git_test.go
+++ b/git_test.go
@@ -109,6 +109,7 @@ func updateReadme(t *testing.T, repo *Repository, content string) (*Oid, *Oid) {
 }
 
 func TestOidZero(t *testing.T) {
+	t.Parallel()
 	var zeroId Oid
 
 	if !zeroId.IsZero() {
@@ -117,6 +118,7 @@ func TestOidZero(t *testing.T) {
 }
 
 func TestEmptyOid(t *testing.T) {
+	t.Parallel()
 	_, err := NewOid("")
 	if err == nil || !IsErrorCode(err, ErrGeneric) {
 		t.Fatal("Should have returned invalid error")

--- a/index_test.go
+++ b/index_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCreateRepoAndStage(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -24,6 +25,7 @@ func TestCreateRepoAndStage(t *testing.T) {
 }
 
 func TestIndexReadTree(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -53,6 +55,7 @@ func TestIndexReadTree(t *testing.T) {
 }
 
 func TestIndexWriteTreeTo(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -72,6 +75,7 @@ func TestIndexWriteTreeTo(t *testing.T) {
 }
 
 func TestIndexAddAndWriteTreeTo(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -106,6 +110,7 @@ func TestIndexAddAndWriteTreeTo(t *testing.T) {
 }
 
 func TestIndexAddAllNoCallback(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -127,6 +132,7 @@ func TestIndexAddAllNoCallback(t *testing.T) {
 }
 
 func TestIndexAddAllCallback(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -155,6 +161,7 @@ func TestIndexAddAllCallback(t *testing.T) {
 }
 
 func TestIndexOpen(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestMergeWithSelf(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -24,6 +25,7 @@ func TestMergeWithSelf(t *testing.T) {
 }
 
 func TestMergeAnalysisWithSelf(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -46,6 +48,7 @@ func TestMergeAnalysisWithSelf(t *testing.T) {
 }
 
 func TestMergeSameFile(t *testing.T) {
+	t.Parallel()
 	file := MergeFileInput{
 		Path:     "test",
 		Mode:     33188,
@@ -68,6 +71,7 @@ func TestMergeSameFile(t *testing.T) {
 
 }
 func TestMergeTreesWithoutAncestor(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -125,6 +129,7 @@ func appendCommit(t *testing.T, repo *Repository) (*Oid, *Oid) {
 }
 
 func TestMergeBase(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/note_test.go
+++ b/note_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCreateNote(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -27,6 +28,7 @@ func TestCreateNote(t *testing.T) {
 }
 
 func TestNoteIterator(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -63,6 +65,7 @@ func TestNoteIterator(t *testing.T) {
 }
 
 func TestRemoveNote(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -86,6 +89,7 @@ func TestRemoveNote(t *testing.T) {
 }
 
 func TestDefaultNoteRef(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/object_test.go
+++ b/object_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestObjectPoymorphism(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -88,6 +89,7 @@ func checkOwner(t *testing.T, repo *Repository, obj Object) {
 }
 
 func TestObjectOwner(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -104,6 +106,7 @@ func TestObjectOwner(t *testing.T) {
 }
 
 func TestObjectPeel(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/odb_test.go
+++ b/odb_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestOdbReadHeader(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -35,6 +36,7 @@ func TestOdbReadHeader(t *testing.T) {
 }
 
 func TestOdbStream(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -64,7 +66,7 @@ func TestOdbStream(t *testing.T) {
 }
 
 func TestOdbHash(t *testing.T) {
-
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -92,6 +94,7 @@ Initial commit.`
 }
 
 func TestOdbForeach(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestPatch(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/push_test.go
+++ b/push_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestRemotePush(t *testing.T) {
+	t.Parallel()
 	repo := createBareTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/reference_test.go
+++ b/reference_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRefModification(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -53,6 +54,7 @@ func TestRefModification(t *testing.T) {
 }
 
 func TestReferenceIterator(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -131,6 +133,7 @@ func TestReferenceIterator(t *testing.T) {
 }
 
 func TestReferenceOwner(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -150,6 +153,7 @@ func TestReferenceOwner(t *testing.T) {
 }
 
 func TestUtil(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -177,6 +181,7 @@ func TestUtil(t *testing.T) {
 }
 
 func TestIsNote(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -210,6 +215,7 @@ func TestIsNote(t *testing.T) {
 }
 
 func TestReferenceIsValidName(t *testing.T) {
+	t.Parallel()
 	if !ReferenceIsValidName("HEAD") {
 		t.Errorf("HEAD should be a valid reference name")
 	}

--- a/remote_test.go
+++ b/remote_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestListRemotes(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -33,6 +34,7 @@ func assertHostname(cert *Certificate, valid bool, hostname string, t *testing.T
 }
 
 func TestCertificateCheck(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -52,6 +54,7 @@ func TestCertificateCheck(t *testing.T) {
 }
 
 func TestRemoteConnect(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -63,6 +66,7 @@ func TestRemoteConnect(t *testing.T) {
 }
 
 func TestRemoteLs(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -81,6 +85,7 @@ func TestRemoteLs(t *testing.T) {
 }
 
 func TestRemoteLsFiltering(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -107,6 +112,7 @@ func TestRemoteLsFiltering(t *testing.T) {
 }
 
 func TestRemotePruneRefs(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -129,6 +135,7 @@ func TestRemotePruneRefs(t *testing.T) {
 }
 
 func TestRemotePrune(t *testing.T) {
+	t.Parallel()
 	remoteRepo := createTestRepo(t)
 	defer cleanupTestRepo(t, remoteRepo)
 

--- a/reset_test.go
+++ b/reset_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestResetToCommit(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	seedTestRepo(t, repo)
 	// create commit to reset to

--- a/revparse_test.go
+++ b/revparse_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestRevparse(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -17,6 +18,7 @@ func TestRevparse(t *testing.T) {
 }
 
 func TestRevparseSingle(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -29,6 +31,7 @@ func TestRevparseSingle(t *testing.T) {
 }
 
 func TestRevparseExt(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/status_test.go
+++ b/status_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestStatusFile(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -27,6 +28,7 @@ func TestStatusFile(t *testing.T) {
 }
 
 func TestStatusList(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestSubmoduleForeach(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCreateTag(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -26,6 +27,7 @@ func TestCreateTag(t *testing.T) {
 }
 
 func TestCreateTagLightweight(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -50,6 +52,7 @@ func TestCreateTagLightweight(t *testing.T) {
 }
 
 func TestListTags(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -79,6 +82,7 @@ func TestListTags(t *testing.T) {
 }
 
 func TestListTagsWithMatch(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -116,6 +120,7 @@ func TestListTagsWithMatch(t *testing.T) {
 }
 
 func TestTagForeach(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -3,6 +3,7 @@ package git
 import "testing"
 
 func TestTreeEntryById(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 
@@ -22,6 +23,7 @@ func TestTreeEntryById(t *testing.T) {
 }
 
 func TestTreeBuilderInsert(t *testing.T) {
+	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
 


### PR DESCRIPTION
This saves about 1s, or 1/3 of the test runtime. The linking is still
much slower, but this we can control.