### PR TITLE
Add check for ErrIterOver in BranchIterator.ForEach

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -73,6 +73,10 @@ func (i *BranchIterator) ForEach(f BranchIteratorFunc) error {
 		}
 	}
 
+	if err != nil && IsErrorCode(err, ErrIterOver) {
+		return nil
+	}
+
 	return err
 }
 


### PR DESCRIPTION
The BranchIterator.ForEach currently returns the ErrIterOver error if no
error had occured during the iteration. This leads to a rather unhelpful
blank error message with the error code -31 when iterating over the
branches.

This commit adds a check for ErrIterOver at the end of the ForEach
method so that the client code only has to worry about checking for nil
as apose to checking for the ErrIterOver error.