### PR TITLE
Add method to fetch raw commit message

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -22,6 +22,10 @@ func (c Commit) Message() string {
 	return C.GoString(C.git_commit_message(c.cast_ptr))
 }
 
+func (c Commit) RawMessage() string {
+	return C.GoString(C.git_commit_message_raw(c.cast_ptr))
+}
+
 func (c Commit) Summary() string {
 	return C.GoString(C.git_commit_summary(c.cast_ptr))
 }


### PR DESCRIPTION
The existing `Commit.Message()` returns the trimmed commit message. In some cases
it is important to retrieve the exact commit message, even if it contains surrounding
newlines.

This adds a new `Commit.RawMessage()` to be able to do that.