### PR TITLE
Write index before writing index tree in seedTestRepo test helper

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -58,6 +58,8 @@ func seedTestRepo(t *testing.T, repo *Repository) (*Oid, *Oid) {
 	checkFatal(t, err)
 	err = idx.AddByPath("README")
 	checkFatal(t, err)
+	err = idx.Write()
+	checkFatal(t, err)
 	treeId, err := idx.WriteTree()
 	checkFatal(t, err)
 


### PR DESCRIPTION
The seedTestRepo() test helper function leaves the seeded repo in an unusual state because the index is not written before the index tree is written. To correct, simply write the index before writing the index tree.

**BEFORE** change, seedTestRepo() leaves repo in this state:

> On branch master
> Changes to be committed:
>   (use "git reset HEAD <file>..." to unstage)
> 
> 	deleted:    README
> 
> Untracked files:
>   (use "git add <file>..." to include in what will be committed)
> 
> 	README
> 

**AFTER** change, seedTestRepo() leaves repo in this state:

> On branch master
> nothing to commit, working directory clean