### PR TITLE
Make New*BackendFromC take unsafe.Pointer as argument

### DIFF
--- a/odb.go
+++ b/odb.go
@@ -36,8 +36,8 @@ func NewOdb() (odb *Odb, err error) {
 	return odb, nil
 }
 
-func NewOdbBackendFromC(ptr *C.git_odb_backend) (backend *OdbBackend) {
-	backend = &OdbBackend{ptr}
+func NewOdbBackendFromC(ptr unsafe.Pointer) (backend *OdbBackend) {
+	backend = &OdbBackend{(*C.git_odb_backend)(ptr)}
 	return backend
 }
 

--- a/refdb.go
+++ b/refdb.go
@@ -9,6 +9,7 @@ extern void _go_git_refdb_backend_free(git_refdb_backend *backend);
 import "C"
 import (
 	"runtime"
+	"unsafe"
 )
 
 type Refdb struct {
@@ -34,8 +35,8 @@ func (v *Repository) NewRefdb() (refdb *Refdb, err error) {
 	return refdb, nil
 }
 
-func NewRefdbBackendFromC(ptr *C.git_refdb_backend) (backend *RefdbBackend) {
-	backend = &RefdbBackend{ptr}
+func NewRefdbBackendFromC(ptr unsafe.Pointer) (backend *RefdbBackend) {
+	backend = &RefdbBackend{(*C.git_refdb_backend)(ptr)}
 	return backend
 }
 


### PR DESCRIPTION
Offers a solution to #314 

The change is simple and allows usage of NewOdbBackendFromC and NewRefdbBackendFromC.
