### PR TITLE
Add Feature query support & panic if libgit2 is not thread-aware

### DIFF
--- a/features.go
+++ b/features.go
@@ -1,0 +1,30 @@
+package git
+
+/*
+#include <git2.h>
+*/
+import "C"
+
+type Feature int
+
+const (
+	// libgit2 was built with threading support
+	FeatureThreads Feature = C.GIT_FEATURE_THREADS
+
+	// libgit2 was built with HTTPS support built-in
+	FeatureHttps Feature = C.GIT_FEATURE_HTTPS
+
+	// libgit2 was build with SSH support built-in
+	FeatureSsh Feature = C.GIT_FEATURE_SSH
+
+	// libgit2 was built with nanosecond support for files
+	FeatureNSec Feature = C.GIT_FEATURE_NSEC
+)
+
+// Features returns a bit-flag of Feature values indicating which features the
+// loaded libgit2 library has.
+func Features() Feature {
+	features := C.git_libgit2_features()
+
+	return Feature(features)
+}

--- a/git.go
+++ b/git.go
@@ -124,6 +124,15 @@ func init() {
 
 	C.git_libgit2_init()
 
+	// Due to the multithreaded nature of Go and its interaction with
+	// calling C functions, we cannot work with a library that was not built
+	// with multi-threading support. The most likely outcome is a segfault
+	// or panic at an incomprehensible time, so let's make it easy by
+	// panicking right here.
+	if Features()&FeatureThreads == 0 {
+		panic("libgit2 was not built with threading support")
+	}
+
 	// This is not something we should be doing, as we may be
 	// stomping all over someone else's setup. The user should do
 	// this themselves or use some binding/wrapper which does it


### PR DESCRIPTION
We ask libgit2 whether it's thread-safe and we panic if it's not. Go's runtime's interaction with C code is inherently multi-threaded so we're bound to crash anyway. Do it at the start with a message that describes the issue.

I'm not sure how to do automated testing for this without incurring twice the cost of building libgit2, but It Works On My Machine.

This fixes #329 