### PR TITLE
Set PKG_CONFIG_PATH

### DIFF
--- a/script/with-static.sh
+++ b/script/with-static.sh
@@ -4,6 +4,7 @@ set -ex
 
 export BUILD="$PWD/vendor/libgit2/build"
 export PCFILE="$BUILD/libgit2.pc"
+export PKG_CONFIG_PATH=$BUILD
 
 FLAGS=$(pkg-config --static --libs $PCFILE) || exit 1
 export CGO_LDFLAGS="$BUILD/libgit2.a -L$BUILD ${FLAGS}"


### PR DESCRIPTION
Set PKG_CONFIG_PATH so that libgit2.pc can be found when building statically linked against libgit2.