### PR TITLE
Link dynamically or statically depending on build flags

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/libgit2"]
+	path = vendor/libgit2
+	url = https://github.com/libgit2/libgit2

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,21 @@
 default: test
 
+build-libgit2:
+	./script/build-libgit2-static.sh
+
+test-static: build-libgit2
+	go run script/check-MakeGitError-thread-lock.go
+	go test -tags static ./...
+
+build-static: build-libgit2
+	go build -tags static ./...
+
+install-static: build-libgit2
+	go install -tags static ./...
+
 test:
 	go run script/check-MakeGitError-thread-lock.go
 	go test ./...
 
-install: build-libgit2
+install:
 	go install ./...

--- a/git.go
+++ b/git.go
@@ -3,7 +3,6 @@ package git
 /*
 #include <git2.h>
 #include <git2/sys/openssl.h>
-#cgo pkg-config: libgit2
 
 #if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 25
 # error "Invalid libgit2 version; this git2go supports libgit2 v0.25"

--- a/git_dynamic.go
+++ b/git_dynamic.go
@@ -1,0 +1,9 @@
+// +build !static
+
+package git
+
+/*
+#cgo pkg-config: libgit2
+#include <git2.h>
+*/
+import "C"

--- a/git_static.go
+++ b/git_static.go
@@ -1,0 +1,11 @@
+// +build static
+
+package git
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/vendor/libgit2/include
+#cgo LDFLAGS: -L${SRCDIR}/vendor/libgit2/build/ -lgit2
+#cgo windows LDFLAGS: -lwinhttp
+#cgo !windows pkg-config: --static ${SRCDIR}/vendor/libgit2/build/libgit2.pc
+*/
+import "C"


### PR DESCRIPTION
This lets us specify which set of rules to link to libgit2 we'll use during
build. Together with the changes to the Makefile, this lets you specify

    make install

or

    make install-static

to build either dynamically against the system-provided library or against the
version specified in the submodule.

The dynamic linking against the system library is still the default in order to
allow for the Go toolchain to build it when it's used as a dependency.