### PR TITLE
Fix memleaks in Tree.EntryBy(Name/Path/Index), fixes #313

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -51,6 +51,7 @@ func (t Tree) EntryByName(filename string) *TreeEntry {
 	if entry == nil {
 		return nil
 	}
+	defer C.git_tree_entry_free(entry)
 
 	return newTreeEntry(entry)
 }
@@ -69,6 +70,7 @@ func (t Tree) EntryByPath(path string) (*TreeEntry, error) {
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
+	defer C.git_tree_entry_free(entry)
 
 	return newTreeEntry(entry), nil
 }
@@ -78,6 +80,7 @@ func (t Tree) EntryByIndex(index uint64) *TreeEntry {
 	if entry == nil {
 		return nil
 	}
+	defer C.git_tree_entry_free(entry)
 
 	return newTreeEntry(entry)
 }

--- a/tree.go
+++ b/tree.go
@@ -51,7 +51,6 @@ func (t Tree) EntryByName(filename string) *TreeEntry {
 	if entry == nil {
 		return nil
 	}
-	defer C.git_tree_entry_free(entry)
 
 	return newTreeEntry(entry)
 }
@@ -80,7 +79,6 @@ func (t Tree) EntryByIndex(index uint64) *TreeEntry {
 	if entry == nil {
 		return nil
 	}
-	defer C.git_tree_entry_free(entry)
 
 	return newTreeEntry(entry)
 }


### PR DESCRIPTION
This fixes a memory leak in the following methods:
* `Tree.EntryByName()`
* `Tree.EntryByPath()`
* `Tree.EntryById()`

This issue was previously reported in https://github.com/libgit2/git2go/issues/313

I decided to use `defer` calls because it's cleaner and more consistent with the conventions used inside the codebase (@carlosmn, you mentioned using a local var in #313).

In addition `go1.8` has [halved the costs of defer calls](https://golang.org/doc/go1.8#defer), I think correctness comes before speed (premature optimization).