### PR TITLE
Add new repository open flags

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -72,6 +72,8 @@ const (
 	RepositoryOpenNoSearch RepositoryOpenFlag = C.GIT_REPOSITORY_OPEN_NO_SEARCH
 	RepositoryOpenCrossFs  RepositoryOpenFlag = C.GIT_REPOSITORY_OPEN_CROSS_FS
 	RepositoryOpenBare     RepositoryOpenFlag = C.GIT_REPOSITORY_OPEN_BARE
+	RepositoryOpenFromEnv  RepositoryOpenFlag = C.GIT_REPOSITORY_OPEN_FROM_ENV
+	RepositoryOpenNoDotGit RepositoryOpenFlag = C.GIT_REPOSITORY_OPEN_NO_DOTGIT
 )
 
 func OpenRepositoryExtended(path string, flags RepositoryOpenFlag, ceiling string) (*Repository, error) {


### PR DESCRIPTION
This adds the new flags for repository open that were introduced in 0.25 of libgit2.

REF: https://github.com/libgit2/libgit2/blob/3b4eb107c21eb855dd651bc2e5904c0b29ece9b7/CHANGELOG.md#api-additions-1