### PR TITLE
Allow building statically via the "static" build tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: go
 
-sudo: required
-
-install: ./script/install-libgit2.sh
-
 go:
   - 1.5
   - 1.6
   - 1.7
   - tip
+
+script: make test-static
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 default: test
 
-build-libgit2:
-	./script/build-libgit2-static.sh
-
 test: build-libgit2
 	go run script/check-MakeGitError-thread-lock.go
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,16 @@ test: build-libgit2
 
 install: build-libgit2
 	go install ./...
+
+build-libgit2:
+	./script/build-libgit2-static.sh
+
+static: build-libgit2
+	go run script/check-MakeGitError-thread-lock.go
+	go test --tags "static" ./...
+
+install-static: build-libgit2
+	go install --tags "static" ./...
+
+test-static: build-libgit2
+	go test --tags "static" ./...

--- a/git.go
+++ b/git.go
@@ -1,17 +1,8 @@
 package git
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/vendor/libgit2/include
-#cgo LDFLAGS: -L${SRCDIR}/vendor/libgit2/build/ -lgit2
-#cgo windows LDFLAGS: -lwinhttp
-#cgo !windows pkg-config: --static ${SRCDIR}/vendor/libgit2/build/libgit2.pc
 #include <git2.h>
 #include <git2/sys/openssl.h>
-
-#if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 25
-# error "Invalid libgit2 version; this git2go supports libgit2 v0.25"
-#endif
-
 */
 import "C"
 import (

--- a/git_dynamic.go
+++ b/git_dynamic.go
@@ -1,0 +1,14 @@
+// +build !static
+
+package git
+
+/*
+#include <git2.h>
+#cgo pkg-config: libgit2
+
+#if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 25
+# error "Invalid libgit2 version; this git2go supports libgit2 v0.25"
+#endif
+
+*/
+import "C"

--- a/git_static.go
+++ b/git_static.go
@@ -1,0 +1,17 @@
+// +build static
+
+package git
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/vendor/libgit2/include
+#cgo LDFLAGS: -L${SRCDIR}/vendor/libgit2/build/ -lgit2
+#cgo windows LDFLAGS: -lwinhttp
+#cgo !windows pkg-config: --static ${SRCDIR}/vendor/libgit2/build/libgit2.pc
+#include <git2.h>
+
+#if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 25
+# error "Invalid libgit2 version; this git2go supports libgit2 v0.25"
+#endif
+
+*/
+import "C"


### PR DESCRIPTION
This hopes to aid in the tension between providing the latest but also being able to provide something that is installable without compilation of libgit2.

In order to keep up with the latest you need to compile, which means going outside of the Go tools. It is then not much of an extra step to run `make` or perform these steps yourself. If you have a different kind of building, you can also pass in the flag yourself.

If you're not interested in that but want to use a released version installed on the system, you already had to use the versioned branches, as even `master` before would just update from one to the other, requiring extra steps to handle that.

New versioned branches that come out of this will also have this capability which should make it easier to use a released version but ship git2go as a single library instead of relying on libgit2 being installed on the target system.