### PR TITLE
[WIP] Use a managed HTTP(S) transport implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ go:
 
 script: make test-static
 
+# The default of --recursive chokes on the libgit2 tests
+git:
+  submodules: false
+
+before_install:
+  - git submodule update --init
+
 matrix:
   allow_failures:
     - go: tip

--- a/git.go
+++ b/git.go
@@ -279,7 +279,7 @@ func MakeGitError(errorCode C.int) error {
 
 	var errMessage string
 	var errClass ErrorClass
-	if errorCode != C.GIT_ITEROVER {
+	if errorCode != C.GIT_ITEROVER && errorCode != C.GIT_EUSER {
 		err := C.giterr_last()
 		if err != nil {
 			errMessage = C.GoString(err.message)

--- a/git.go
+++ b/git.go
@@ -129,6 +129,14 @@ func init() {
 		panic("libgit2 was not built with threading support")
 	}
 
+	if err := RegisterManagedHttp(); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterManagedHttps(); err != nil {
+		panic(err)
+	}
+
 	// This is not something we should be doing, as we may be
 	// stomping all over someone else's setup. The user should do
 	// this themselves or use some binding/wrapper which does it

--- a/http.go
+++ b/http.go
@@ -208,6 +208,9 @@ func (self *ManagedHttpStream) sendRequest() error {
 		if resp.StatusCode == http.StatusUnauthorized {
 			resp.Body.Close()
 			var cred *C.git_cred
+
+			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
 			ret := C.git_transport_smart_credentials(&cred, self.owner.owner, nil, C.GIT_CREDTYPE_USERPASS_PLAINTEXT)
 
 			if ret != 0 {

--- a/http.go
+++ b/http.go
@@ -423,8 +423,7 @@ func smartSubtransportRead(s *C.git_smart_subtransport_stream, data *C.char, l C
 			return 0
 		}
 
-		setLibgit2Error(err)
-		return -1
+		return setLibgit2Error(err)
 	}
 
 	*read = C.size_t(n)

--- a/http.go
+++ b/http.go
@@ -295,7 +295,7 @@ func httpAction(out **C.git_smart_subtransport_stream, t *C.git_smart_subtranspo
 
 	stream := C.calloc(1, C.size_t(unsafe.Sizeof(C.managed_smart_subtransport_stream{})))
 	managedPtr := pointerHandles.Track(managed)
-	C._go_git_setup_smart_subtransport_stream(stream, managedPtr)
+	C._go_git_setup_smart_subtransport_stream((*C.managed_smart_subtransport_stream)(stream), managedPtr)
 
 	*out = (*C.git_smart_subtransport_stream)(stream)
 	return 0
@@ -348,7 +348,7 @@ func httpSmartSubtransportCb(out **C.git_smart_subtransport, owner *C.git_transp
 	transport := C.calloc(1, C.size_t(unsafe.Sizeof(C.managed_smart_subtransport{})))
 	managed := &ManagedTransport{owner: owner}
 	managedPtr := pointerHandles.Track(managed)
-	C._go_git_setup_smart_subtransport(transport, managedPtr)
+	C._go_git_setup_smart_subtransport((*C.managed_smart_subtransport)(transport), managedPtr)
 
 	*out = (*C.git_smart_subtransport)(transport)
 	return 0

--- a/http.go
+++ b/http.go
@@ -335,7 +335,7 @@ func getSmartSubtransportStreamInterface(_s *C.git_smart_subtransport_stream) (S
 }
 
 //export smartSubtransportRead
-func smartSubtransportRead(s *C.git_smart_subtransport_stream, data unsafe.Pointer, l C.size_t, read *C.size_t) C.int {
+func smartSubtransportRead(s *C.git_smart_subtransport_stream, data *C.char, l C.size_t, read *C.size_t) C.int {
 	stream, err := getSmartSubtransportStreamInterface(s)
 	if err != nil {
 		return setLibgit2Error(err)
@@ -345,7 +345,7 @@ func smartSubtransportRead(s *C.git_smart_subtransport_stream, data unsafe.Point
 	header := (*reflect.SliceHeader)(unsafe.Pointer(&p))
 	header.Cap = int(l)
 	header.Len = int(l)
-	header.Data = uintptr(data)
+	header.Data = uintptr(unsafe.Pointer(data))
 
 	n, err := stream.Read(p)
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -1,0 +1,315 @@
+package git
+
+/*
+#include <git2.h>
+#include <git2/sys/transport.h>
+
+typedef struct {
+    git_smart_subtransport parent;
+    void *ptr;
+} managed_smart_subtransport;
+
+typedef struct {
+    git_smart_subtransport_stream parent;
+    void *ptr;
+} managed_smart_subtransport_stream;
+
+int _go_git_transport_register(const char *scheme);
+int _go_git_transport_smart(git_transport **out, git_remote *owner);
+void _go_git_setup_smart_subtransport(managed_smart_subtransport *t, void *ptr);
+void _go_git_setup_smart_subtransport_stream(managed_smart_subtransport_stream *t, void *ptr);
+*/
+import "C"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"runtime"
+	//"runtime/debug"
+	"unsafe"
+)
+
+type SmartService int
+
+const (
+	SmartServiceUploadpackLs  = C.GIT_SERVICE_UPLOADPACK_LS
+	SmartServiceUploadpack    = C.GIT_SERVICE_UPLOADPACK
+	SmartServiceReceivepackLs = C.GIT_SERVICE_RECEIVEPACK_LS
+	SmartServiceReceivepack   = C.GIT_SERVICE_RECEIVEPACK
+)
+
+type SmartSubtransport interface {
+	Action(url string, action SmartService) (SmartSubtransportStream, error)
+	Close() error
+	Free()
+}
+
+type SmartSubtransportStream interface {
+	Read(buf []byte) (int, error)
+	Write(buf []byte) error
+	Free()
+}
+
+func RegisterManagedHttp() error {
+	httpStr := C.CString("http")
+	defer C.free(unsafe.Pointer(httpStr))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	ret := C._go_git_transport_register(httpStr)
+	if ret != 0 {
+		return MakeGitError(ret)
+	}
+
+	return nil
+}
+
+func RegisterManagedHttps() error {
+	httpsStr := C.CString("https")
+	defer C.free(unsafe.Pointer(httpsStr))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	ret := C._go_git_transport_register(httpsStr)
+	if ret != 0 {
+		return MakeGitError(ret)
+	}
+
+	return nil
+}
+
+type ManagedTransport struct{}
+
+func (self *ManagedTransport) Action(url string, action SmartService) (SmartSubtransportStream, error) {
+	var req *http.Request
+	var err error
+	switch action {
+	case SmartServiceUploadpackLs:
+		req, err = http.NewRequest("GET", url+"/info/refs?service=git-upload-pack", nil)
+
+	case SmartServiceUploadpack:
+		req, err = http.NewRequest("POST", url+"/git-upload-pack", nil)
+		if err != nil {
+			break
+		}
+
+		req.Header["Content-Type"] = []string{"application/x-git-upload-pack-request"}
+
+	case SmartServiceReceivepackLs:
+		req, err = http.NewRequest("GET", url+"/info/refs?service=git-receive-pack", nil)
+
+	case SmartServiceReceivepack:
+		req, err = http.NewRequest("POST", url+"/info/refs?service=git-upload-pack", nil)
+		if err != nil {
+			break
+		}
+
+		req.Header["Content-Type"] = []string{"application/x-git-receive-pack-request"}
+	default:
+		err = errors.New("unknown action")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header["User-Agent"] = []string{"git/2.0 (git2go)"}
+	return newManagedHttpStream(req), nil
+}
+
+func (self *ManagedTransport) Close() error {
+	return nil
+}
+
+func (self *ManagedTransport) Free() {
+}
+
+type ManagedHttpStream struct {
+	req         *http.Request
+	resp        *http.Response
+	postBuffer  bytes.Buffer
+	sentRequest bool
+}
+
+func newManagedHttpStream(req *http.Request) *ManagedHttpStream {
+	return &ManagedHttpStream{
+		req: req,
+	}
+}
+
+func (self *ManagedHttpStream) Read(buf []byte) (int, error) {
+	if !self.sentRequest {
+		if err := self.sendRequest(); err != nil {
+			return 0, err
+		}
+	}
+
+	return self.resp.Body.Read(buf)
+}
+
+func (self *ManagedHttpStream) Write(buf []byte) error {
+	// We write it all into a buffer and send it off when the transport asks
+	// us to read.
+	self.postBuffer.Write(buf)
+	return nil
+}
+
+func (self *ManagedHttpStream) Free() {
+	self.resp.Body.Close()
+}
+
+func (self *ManagedHttpStream) sendRequest() error {
+	self.req.Body = ioutil.NopCloser(&self.postBuffer)
+	resp, err := http.DefaultClient.Do(self.req)
+	if err != nil {
+		return err
+	}
+
+	self.sentRequest = true
+	self.resp = resp
+	return nil
+}
+
+func setLibgit2Error(err error) C.int {
+	cstr := C.CString(err.Error())
+	defer C.free(unsafe.Pointer(cstr))
+	C.giterr_set_str(C.GITERR_NET, cstr)
+
+	return -1
+}
+
+//export httpAction
+func httpAction(out **C.git_smart_subtransport_stream, t *C.git_smart_subtransport, url *C.char, action C.git_smart_service_t) C.int {
+	transport, err := getSmartSubtransportInterface(t)
+	if err != nil {
+		return setLibgit2Error(err)
+	}
+
+	managed, err := transport.Action(C.GoString(url), SmartService(action))
+	if err != nil {
+		return setLibgit2Error(err)
+	}
+
+	stream := C.calloc(1, C.size_t(unsafe.Sizeof(C.managed_smart_subtransport_stream{})))
+	managedPtr := pointerHandles.Track(managed)
+	C._go_git_setup_smart_subtransport_stream(stream, managedPtr)
+
+	*out = (*C.git_smart_subtransport_stream)(stream)
+	return 0
+}
+
+//export httpClose
+func httpClose(t *C.git_smart_subtransport) C.int {
+	transport, err := getSmartSubtransportInterface(t)
+	if err != nil {
+		return setLibgit2Error(err)
+	}
+
+	if err := transport.Close(); err != nil {
+		return setLibgit2Error(err)
+	}
+
+	return 0
+}
+
+//export httpFree
+func httpFree(transport *C.git_smart_subtransport) {
+	wrapperPtr := (*C.managed_smart_subtransport)(unsafe.Pointer(transport))
+	pointerHandles.Untrack(wrapperPtr.ptr)
+}
+
+var errNoSmartSubtransport = errors.New("passed object does not implement SmartSubtransport")
+
+func getSmartSubtransportInterface(_t *C.git_smart_subtransport) (SmartSubtransport, error) {
+	wrapperPtr := (*C.managed_smart_subtransport)(unsafe.Pointer(_t))
+
+	transport, ok := pointerHandles.Get(wrapperPtr.ptr).(SmartSubtransport)
+	if !ok {
+		return nil, errNoSmartSubtransport
+	}
+
+	return transport, nil
+}
+
+//export httpTransportCb
+func httpTransportCb(out **C.git_transport, owner *C.git_remote, param unsafe.Pointer) C.int {
+	return C._go_git_transport_smart(out, owner)
+}
+
+//export httpSmartSubtransportCb
+func httpSmartSubtransportCb(out **C.git_smart_subtransport, owner *C.git_transport, param unsafe.Pointer) C.int {
+	if out == nil {
+		return -1
+	}
+
+	transport := C.calloc(1, C.size_t(unsafe.Sizeof(C.managed_smart_subtransport{})))
+	managed := &ManagedTransport{}
+	managedPtr := pointerHandles.Track(managed)
+	C._go_git_setup_smart_subtransport(transport, managedPtr)
+
+	*out = (*C.git_smart_subtransport)(transport)
+	return 0
+}
+
+var errNoSmartSubtransportStream = errors.New("passed object does not implement SmartSubtransportStream")
+
+func getSmartSubtransportStreamInterface(_s *C.git_smart_subtransport_stream) (SmartSubtransportStream, error) {
+	wrapperPtr := (*C.managed_smart_subtransport_stream)(unsafe.Pointer(_s))
+
+	transport, ok := pointerHandles.Get(wrapperPtr.ptr).(SmartSubtransportStream)
+	if !ok {
+		return nil, errNoSmartSubtransportStream
+	}
+
+	return transport, nil
+}
+
+//export smartSubtransportRead
+func smartSubtransportRead(s *C.git_smart_subtransport_stream, data unsafe.Pointer, l C.size_t, read *C.size_t) C.int {
+	stream, err := getSmartSubtransportStreamInterface(s)
+	if err != nil {
+		return setLibgit2Error(err)
+	}
+
+	var p []byte
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&p))
+	header.Cap = int(l)
+	header.Len = int(l)
+	header.Data = uintptr(data)
+
+	n, err := stream.Read(p)
+	if err != nil {
+		return setLibgit2Error(err)
+	}
+
+	*read = C.size_t(n)
+	return 0
+}
+
+//export smartSubtransportWrite
+func smartSubtransportWrite(s *C.git_smart_subtransport_stream, data unsafe.Pointer, l C.size_t) C.int {
+	stream, err := getSmartSubtransportStreamInterface(s)
+	if err != nil {
+		return setLibgit2Error(err)
+	}
+
+	var p []byte
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&p))
+	header.Cap = int(l)
+	header.Len = int(l)
+	header.Data = uintptr(data)
+
+	if err := stream.Write(p); err != nil {
+		return setLibgit2Error(err)
+	}
+
+	return 0
+}
+
+//export smartSubtransportFree
+func smartSubtransportFree(s *C.git_smart_subtransport_stream) {
+}

--- a/http.go
+++ b/http.go
@@ -24,12 +24,10 @@ import "C"
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"runtime"
-	//"runtime/debug"
 	"unsafe"
 )
 

--- a/remote.go
+++ b/remote.go
@@ -141,6 +141,13 @@ type ProxyOptions struct {
 	Url string
 }
 
+func proxyOptionsFromC(copts *C.git_proxy_options) ProxyOptions {
+	return ProxyOptions{
+		Type: ProxyType(copts._type),
+		Url:  C.GoString(copts.url),
+	}
+}
+
 type Remote struct {
 	ptr       *C.git_remote
 	callbacks RemoteCallbacks

--- a/remote_test.go
+++ b/remote_test.go
@@ -184,3 +184,26 @@ func TestRemotePrune(t *testing.T) {
 		t.Fatal("Expected error getting a pruned reference")
 	}
 }
+
+func TestRemoteCredentialsCalled(t *testing.T) {
+	t.Parallel()
+
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	remote, err := repo.Remotes.CreateAnonymous("https://github.com/libgit2/non-existent")
+	checkFatal(t, err)
+
+	fetchOpts := FetchOptions{
+		RemoteCallbacks: RemoteCallbacks{
+			CredentialsCallback: func(url, username string, allowedTypes CredType) (ErrorCode, *Cred) {
+				return ErrUser, nil
+			},
+		},
+	}
+
+	err = remote.Fetch(nil, &fetchOpts, "fetch")
+	if !IsErrorCode(err, ErrUser) {
+		t.Fatal("Bad Fetch return, expected ErrUser, got", err)
+	}
+}

--- a/submodule.go
+++ b/submodule.go
@@ -15,7 +15,6 @@ import (
 type SubmoduleUpdateOptions struct {
 	*CheckoutOpts
 	*FetchOptions
-	CloneCheckoutStrategy CheckoutStrategy
 }
 
 // Submodule
@@ -369,7 +368,6 @@ func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *S
 
 	populateCheckoutOpts(&ptr.checkout_opts, opts.CheckoutOpts)
 	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
-	ptr.clone_checkout_strategy = C.uint(opts.CloneCheckoutStrategy)
 
 	return nil
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -198,7 +198,9 @@ int _go_git_transport_smart(git_transport **out, git_remote *owner)
 
 void _go_git_setup_smart_subtransport(managed_smart_subtransport *t, void *ptr)
 {
-	t->parent.action = httpAction;
+	typedef int (*transport_action)(git_smart_subtransport_stream **out, git_smart_subtransport *transport, const char *url, git_smart_service_t action);
+
+	t->parent.action = (transport_action)httpAction;
 	t->parent.close = httpClose;
 	t->parent.free = httpFree;
 
@@ -207,8 +209,10 @@ void _go_git_setup_smart_subtransport(managed_smart_subtransport *t, void *ptr)
 
 void _go_git_setup_smart_subtransport_stream(managed_smart_subtransport_stream *s, void *ptr)
 {
+	typedef int (*transport_stream_write)(git_smart_subtransport_stream *stream, const char *buffer, size_t len);
+
 	s->parent.read = smartSubtransportRead;
-	s->parent.write = smartSubtransportWrite;
+	s->parent.write = (transport_stream_write)smartSubtransportWrite;
 	s->parent.free = smartSubtransportFree;
 
 	s->ptr = ptr;


### PR DESCRIPTION
This is a bit like #372 but goes further by replacing the whole HTTP stack and just leaving the logic in libgit2. This lets us use the Go HTTP code as well, instead of the one in the library.

The current state is enough to let the tests work but there is no custom proxy configuration available and we don't currently test that authentication actually works.

Proxy support depends on libgit2/libgit2#4206 or similar getting merged. I guess we'll have to add poxyproxy to our tests as well so it doesn't regress.

While this is useful by itself (by taking us completely away from OpenSSL and libcurl in libgit2), a potentially more exciting outcome might be to build on the lessons from this to build a managed ssh transport, which would eliminate the need for libssh2.