### PR TITLE
rebase: fix int overflows on GIT_REBASE_NO_OPERATION

### DIFF
--- a/rebase.go
+++ b/rebase.go
@@ -155,9 +155,9 @@ func (rebase *Rebase) CurrentOperationIndex() (uint, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	operationIndex := int(C.git_rebase_operation_current(rebase.ptr))
-	if operationIndex == C.GIT_REBASE_NO_OPERATION {
-		return 0, MakeGitError(C.GIT_REBASE_NO_OPERATION)
+	operationIndex := uint(C.git_rebase_operation_current(rebase.ptr))
+	if operationIndex == uint(C.GIT_REBASE_NO_OPERATION) {
+		return 0, MakeGitError(C.int(operationIndex))
 	}
 
 	return uint(operationIndex), nil


### PR DESCRIPTION
Fix int overflows on `GIT_REBASE_NO_OPERATION`.
It will fail on Go tip(and maybe 1.8), See https://travis-ci.org/libgit2/git2go/jobs/234362572#L391-L392.