### PR TITLE
remote: add keep-alive and references to the repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
   - 1.7
+  - 1.8
   - tip
 
 script: make test-static


### PR DESCRIPTION
Especially in 1.8, the garbage collector can decide to finalize an object even
as we are in one of its methods. This means it can free a remote while we're in
one of its calls, as we're referencing the pointer inside the object, rather
than the `Remote` itself.