### PR TITLE
Added Commit.ExtractSignature to wrap git_commit_extract_signature

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -26,6 +26,27 @@ func (c Commit) RawMessage() string {
 	return C.GoString(C.git_commit_message_raw(c.cast_ptr))
 }
 
+func (c Commit) ExtractSignature() (string, string, error) {
+
+	var c_signed C.git_buf
+	defer C.git_buf_free(&c_signed)
+
+	var c_signature C.git_buf
+	defer C.git_buf_free(&c_signature)
+
+	oid := c.Id()
+	
+	repo := C.git_commit_owner(c.cast_ptr)
+	ret := C.git_commit_extract_signature(&c_signature, &c_signed, repo, oid.toC(), nil)
+	
+	if ret < 0 {
+		return "", "", MakeGitError(ret) 
+	} else {
+		return C.GoString(c_signature.ptr), C.GoString(c_signed.ptr), nil
+	}
+	
+}
+
 func (c Commit) Summary() string {
 	return C.GoString(C.git_commit_summary(c.cast_ptr))
 }


### PR DESCRIPTION
As in the subject. The method ExtractSignature wraps git_commit_extract_signature. This is useful in gpg-signed commits, to retrieve the stuff which has been signed and the corresponding signature. This fixes #388 