### PR TITLE
KeepAlive all the things

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -76,6 +76,7 @@ func (v *Repository) BlameFile(path string, opts *BlameOptions) (*Blame, error) 
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_blame_file(&blamePtr, v.ptr, cpath, copts)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -88,11 +89,15 @@ type Blame struct {
 }
 
 func (blame *Blame) HunkCount() int {
-	return int(C.git_blame_get_hunk_count(blame.ptr))
+	ret := int(C.git_blame_get_hunk_count(blame.ptr))
+	runtime.KeepAlive(blame)
+
+	return ret
 }
 
 func (blame *Blame) HunkByIndex(index int) (BlameHunk, error) {
 	ptr := C.git_blame_get_hunk_byindex(blame.ptr, C.uint32_t(index))
+	runtime.KeepAlive(blame)
 	if ptr == nil {
 		return BlameHunk{}, ErrInvalid
 	}
@@ -101,6 +106,7 @@ func (blame *Blame) HunkByIndex(index int) (BlameHunk, error) {
 
 func (blame *Blame) HunkByLine(lineno int) (BlameHunk, error) {
 	ptr := C.git_blame_get_hunk_byline(blame.ptr, C.size_t(lineno))
+	runtime.KeepAlive(blame)
 	if ptr == nil {
 		return BlameHunk{}, ErrInvalid
 	}

--- a/branch.go
+++ b/branch.go
@@ -88,6 +88,7 @@ func (repo *Repository) NewBranchIterator(flags BranchType) (*BranchIterator, er
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_branch_iterator_new(&ptr, repo.ptr, refType)
+	runtime.KeepAlive(repo)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -106,6 +107,8 @@ func (repo *Repository) CreateBranch(branchName string, target *Commit, force bo
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_create(&ptr, repo.ptr, cBranchName, target.cast_ptr, cForce)
+	runtime.KeepAlive(repo)
+	runtime.KeepAlive(target)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -117,6 +120,7 @@ func (b *Branch) Delete() error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	ret := C.git_branch_delete(b.Reference.ptr)
+	runtime.KeepAlive(b.Reference)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -133,6 +137,7 @@ func (b *Branch) Move(newBranchName string, force bool) (*Branch, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_move(&ptr, b.Reference.ptr, cNewBranchName, cForce)
+	runtime.KeepAlive(b.Reference)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -145,6 +150,7 @@ func (b *Branch) IsHead() (bool, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_is_head(b.Reference.ptr)
+	runtime.KeepAlive(b.Reference)
 	switch ret {
 	case 1:
 		return true, nil
@@ -165,6 +171,7 @@ func (repo *Repository) LookupBranch(branchName string, bt BranchType) (*Branch,
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_lookup(&ptr, repo.ptr, cName, C.git_branch_t(bt))
+	runtime.KeepAlive(repo)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -179,6 +186,7 @@ func (b *Branch) Name() (string, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_name(&cName, b.Reference.ptr)
+	runtime.KeepAlive(b.Reference)
 	if ret < 0 {
 		return "", MakeGitError(ret)
 	}
@@ -196,6 +204,7 @@ func (repo *Repository) RemoteName(canonicalBranchName string) (string, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_remote_name(&nameBuf, repo.ptr, cName)
+	runtime.KeepAlive(repo)
 	if ret < 0 {
 		return "", MakeGitError(ret)
 	}
@@ -212,6 +221,7 @@ func (b *Branch) SetUpstream(upstreamName string) error {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_set_upstream(b.Reference.ptr, cName)
+	runtime.KeepAlive(b.Reference)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -225,6 +235,7 @@ func (b *Branch) Upstream() (*Reference, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_upstream(&ptr, b.Reference.ptr)
+	runtime.KeepAlive(b.Reference)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -241,6 +252,7 @@ func (repo *Repository) UpstreamName(canonicalBranchName string) (string, error)
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_branch_upstream_name(&nameBuf, repo.ptr, cName)
+	runtime.KeepAlive(repo)
 	if ret < 0 {
 		return "", MakeGitError(ret)
 	}

--- a/checkout.go
+++ b/checkout.go
@@ -188,6 +188,7 @@ func (v *Repository) CheckoutHead(opts *CheckoutOpts) error {
 	defer freeCheckoutOpts(cOpts)
 
 	ret := C.git_checkout_head(v.ptr, cOpts)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -211,6 +212,7 @@ func (v *Repository) CheckoutIndex(index *Index, opts *CheckoutOpts) error {
 	defer freeCheckoutOpts(cOpts)
 
 	ret := C.git_checkout_index(v.ptr, iptr, cOpts)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -226,6 +228,7 @@ func (v *Repository) CheckoutTree(tree *Tree, opts *CheckoutOpts) error {
 	defer freeCheckoutOpts(cOpts)
 
 	ret := C.git_checkout_tree(v.ptr, tree.ptr, cOpts)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}

--- a/cherrypick.go
+++ b/cherrypick.go
@@ -66,6 +66,8 @@ func (v *Repository) Cherrypick(commit *Commit, opts CherrypickOptions) error {
 	defer freeCherrypickOpts(cOpts)
 
 	ecode := C.git_cherrypick(v.ptr, commit.cast_ptr, cOpts)
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(commit)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}

--- a/commit.go
+++ b/commit.go
@@ -18,15 +18,19 @@ type Commit struct {
 	cast_ptr *C.git_commit
 }
 
-func (c Commit) Message() string {
-	return C.GoString(C.git_commit_message(c.cast_ptr))
+func (c *Commit) Message() string {
+	ret := C.GoString(C.git_commit_message(c.cast_ptr))
+	runtime.KeepAlive(c)
+	return ret
 }
 
-func (c Commit) RawMessage() string {
-	return C.GoString(C.git_commit_message_raw(c.cast_ptr))
+func (c *Commit) RawMessage() string {
+	ret := C.GoString(C.git_commit_message_raw(c.cast_ptr))
+	runtime.KeepAlive(c)
+	return ret
 }
 
-func (c Commit) ExtractSignature() (string, string, error) {
+func (c *Commit) ExtractSignature() (string, string, error) {
 
 	var c_signed C.git_buf
 	defer C.git_buf_free(&c_signed)
@@ -40,7 +44,7 @@ func (c Commit) ExtractSignature() (string, string, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	ret := C.git_commit_extract_signature(&c_signature, &c_signed, repo, oid.toC(), nil)
-
+	runtime.KeepAlive(oid)
 	if ret < 0 {
 		return "", "", MakeGitError(ret)
 	} else {
@@ -49,17 +53,20 @@ func (c Commit) ExtractSignature() (string, string, error) {
 
 }
 
-func (c Commit) Summary() string {
-	return C.GoString(C.git_commit_summary(c.cast_ptr))
+func (c *Commit) Summary() string {
+	ret := C.GoString(C.git_commit_summary(c.cast_ptr))
+	runtime.KeepAlive(c)
+	return ret
 }
 
-func (c Commit) Tree() (*Tree, error) {
+func (c *Commit) Tree() (*Tree, error) {
 	var ptr *C.git_tree
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	err := C.git_commit_tree(&ptr, c.cast_ptr)
+	runtime.KeepAlive(c)
 	if err < 0 {
 		return nil, MakeGitError(err)
 	}
@@ -67,18 +74,24 @@ func (c Commit) Tree() (*Tree, error) {
 	return allocTree(ptr, c.repo), nil
 }
 
-func (c Commit) TreeId() *Oid {
-	return newOidFromC(C.git_commit_tree_id(c.cast_ptr))
+func (c *Commit) TreeId() *Oid {
+	ret := newOidFromC(C.git_commit_tree_id(c.cast_ptr))
+	runtime.KeepAlive(c)
+	return c
 }
 
-func (c Commit) Author() *Signature {
+func (c *Commit) Author() *Signature {
 	cast_ptr := C.git_commit_author(c.cast_ptr)
-	return newSignatureFromC(cast_ptr)
+	ret := newSignatureFromC(cast_ptr)
+	runtime.KeepAlive(c)
+	return ret
 }
 
-func (c Commit) Committer() *Signature {
+func (c *Commit) Committer() *Signature {
 	cast_ptr := C.git_commit_committer(c.cast_ptr)
-	return newSignatureFromC(cast_ptr)
+	ret := newSignatureFromC(cast_ptr)
+	runtime.KeepAlive(c)
+	return ret
 }
 
 func (c *Commit) Parent(n uint) *Commit {

--- a/commit.go
+++ b/commit.go
@@ -35,16 +35,18 @@ func (c Commit) ExtractSignature() (string, string, error) {
 	defer C.git_buf_free(&c_signature)
 
 	oid := c.Id()
-	
 	repo := C.git_commit_owner(c.cast_ptr)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	ret := C.git_commit_extract_signature(&c_signature, &c_signed, repo, oid.toC(), nil)
-	
+
 	if ret < 0 {
-		return "", "", MakeGitError(ret) 
+		return "", "", MakeGitError(ret)
 	} else {
 		return C.GoString(c_signature.ptr), C.GoString(c_signed.ptr), nil
 	}
-	
+
 }
 
 func (c Commit) Summary() string {

--- a/commit.go
+++ b/commit.go
@@ -77,7 +77,7 @@ func (c *Commit) Tree() (*Tree, error) {
 func (c *Commit) TreeId() *Oid {
 	ret := newOidFromC(C.git_commit_tree_id(c.cast_ptr))
 	runtime.KeepAlive(c)
-	return c
+	return ret
 }
 
 func (c *Commit) Author() *Signature {
@@ -101,15 +101,21 @@ func (c *Commit) Parent(n uint) *Commit {
 		return nil
 	}
 
-	return allocCommit(cobj, c.repo)
+	parent := allocCommit(cobj, c.repo)
+	runtime.KeepAlive(c)
+	return parent
 }
 
 func (c *Commit) ParentId(n uint) *Oid {
-	return newOidFromC(C.git_commit_parent_id(c.cast_ptr, C.uint(n)))
+	ret := newOidFromC(C.git_commit_parent_id(c.cast_ptr, C.uint(n)))
+	runtime.KeepAlive(c)
+	return ret
 }
 
 func (c *Commit) ParentCount() uint {
-	return uint(C.git_commit_parentcount(c.cast_ptr))
+	ret := uint(C.git_commit_parentcount(c.cast_ptr))
+	runtime.KeepAlive(c)
+	return ret
 }
 
 func (c *Commit) Amend(refname string, author, committer *Signature, message string, tree *Tree) (*Oid, error) {
@@ -142,6 +148,9 @@ func (c *Commit) Amend(refname string, author, committer *Signature, message str
 	oid := new(Oid)
 
 	cerr := C.git_commit_amend(oid.toC(), c.cast_ptr, cref, authorSig, committerSig, nil, cmsg, tree.cast_ptr)
+	runtime.KeepAlive(oid)
+	runtime.KeepAlive(c)
+	runtime.KeepAlive(tree)
 	if cerr < 0 {
 		return nil, MakeGitError(cerr)
 	}

--- a/describe.go
+++ b/describe.go
@@ -128,6 +128,7 @@ func (c *Commit) Describe(opts *DescribeOptions) (*DescribeResult, error) {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_describe_commit(&resultPtr, c.ptr, cDescribeOpts)
+	runtime.KeepAlive(c)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -162,6 +163,7 @@ func (repo *Repository) DescribeWorkdir(opts *DescribeOptions) (*DescribeResult,
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_describe_workdir(&resultPtr, repo.ptr, cDescribeOpts)
+	runtime.KeepAlive(repo)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -206,6 +208,7 @@ func (result *DescribeResult) Format(opts *DescribeFormatOptions) (string, error
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_describe_format(&resultBuf, result.ptr, cFormatOpts)
+	runtime.KeepAlive(result)
 	if ecode < 0 {
 		return "", MakeGitError(ecode)
 	}

--- a/diff.go
+++ b/diff.go
@@ -127,14 +127,17 @@ func diffLineFromC(line *C.git_diff_line) DiffLine {
 }
 
 type Diff struct {
-	ptr *C.git_diff
+	ptr  *C.git_diff
+	repo *Repository
 }
 
 func (diff *Diff) NumDeltas() (int, error) {
 	if diff.ptr == nil {
 		return -1, ErrInvalid
 	}
-	return int(C.git_diff_num_deltas(diff.ptr)), nil
+	ret := int(C.git_diff_num_deltas(diff.ptr))
+	runtime.KeepAlive(diff)
+	return ret, nil
 }
 
 func (diff *Diff) GetDelta(index int) (DiffDelta, error) {
@@ -142,16 +145,19 @@ func (diff *Diff) GetDelta(index int) (DiffDelta, error) {
 		return DiffDelta{}, ErrInvalid
 	}
 	ptr := C.git_diff_get_delta(diff.ptr, C.size_t(index))
-	return diffDeltaFromC(ptr), nil
+	ret := diffDeltaFromC(ptr)
+	runtime.KeepAlive(diff)
+	return ret, nil
 }
 
-func newDiffFromC(ptr *C.git_diff) *Diff {
+func newDiffFromC(ptr *C.git_diff, repo *Repository) *Diff {
 	if ptr == nil {
 		return nil
 	}
 
 	diff := &Diff{
-		ptr: ptr,
+		ptr:  ptr,
+		repo: repo,
 	}
 
 	runtime.SetFinalizer(diff, (*Diff).Free)
@@ -187,6 +193,7 @@ func (diff *Diff) FindSimilar(opts *DiffFindOptions) error {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_diff_find_similar(diff.ptr, copts)
+	runtime.KeepAlive(diff)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -209,15 +216,21 @@ func (stats *DiffStats) Free() error {
 }
 
 func (stats *DiffStats) Insertions() int {
-	return int(C.git_diff_stats_insertions(stats.ptr))
+	ret := int(C.git_diff_stats_insertions(stats.ptr))
+	runtime.KeepAlive(stats)
+	return ret
 }
 
 func (stats *DiffStats) Deletions() int {
-	return int(C.git_diff_stats_deletions(stats.ptr))
+	ret := int(C.git_diff_stats_deletions(stats.ptr))
+	runtime.KeepAlive(stats)
+	return ret
 }
 
 func (stats *DiffStats) FilesChanged() int {
-	return int(C.git_diff_stats_files_changed(stats.ptr))
+	ret := int(C.git_diff_stats_files_changed(stats.ptr))
+	runtime.KeepAlive(stats)
+	return ret
 }
 
 type DiffStatsFormat int
@@ -240,6 +253,7 @@ func (stats *DiffStats) String(format DiffStatsFormat,
 
 	ret := C.git_diff_stats_to_buf(&buf,
 		stats.ptr, C.git_diff_stats_format_t(format), C.size_t(width))
+	runtime.KeepAlive(stats)
 	if ret < 0 {
 		return "", MakeGitError(ret)
 	}
@@ -253,7 +267,9 @@ func (diff *Diff) Stats() (*DiffStats, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if ecode := C.git_diff_get_stats(&stats.ptr, diff.ptr); ecode < 0 {
+	ecode := C.git_diff_get_stats(&stats.ptr, diff.ptr)
+	runtime.KeepAlive(diff)
+	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
 	runtime.SetFinalizer(stats, (*DiffStats).Free)
@@ -301,6 +317,7 @@ func (diff *Diff) ForEach(cbFile DiffForEachFileCallback, detail DiffDetail) err
 	defer pointerHandles.Untrack(handle)
 
 	ecode := C._go_git_diff_foreach(diff.ptr, 1, intHunks, intLines, handle)
+	runtime.KeepAlive(diff)
 	if ecode < 0 {
 		return data.Error
 	}
@@ -380,6 +397,7 @@ func (diff *Diff) Patch(deltaIndex int) (*Patch, error) {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_patch_from_diff(&patchPtr, diff.ptr, C.size_t(deltaIndex))
+	runtime.KeepAlive(diff)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -537,7 +555,7 @@ func diffNotifyCb(_diff_so_far unsafe.Pointer, delta_to_add *C.git_diff_delta, m
 
 	if data != nil {
 		if data.Diff == nil {
-			data.Diff = newDiffFromC(diff_so_far)
+			data.Diff = newDiffFromC(diff_so_far, nil)
 		}
 
 		err := data.Callback(data.Diff, diffDeltaFromC(delta_to_add), C.GoString(matched_pathspec))
@@ -618,6 +636,8 @@ func (v *Repository) DiffTreeToTree(oldTree, newTree *Tree, opts *DiffOptions) (
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_diff_tree_to_tree(&diffPtr, v.ptr, oldPtr, newPtr, copts)
+	runtime.KeepAlive(oldTree)
+	runtime.KeepAlive(newTree)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -625,7 +645,7 @@ func (v *Repository) DiffTreeToTree(oldTree, newTree *Tree, opts *DiffOptions) (
 	if notifyData != nil && notifyData.Diff != nil {
 		return notifyData.Diff, nil
 	}
-	return newDiffFromC(diffPtr), nil
+	return newDiffFromC(diffPtr, v), nil
 }
 
 func (v *Repository) DiffTreeToWorkdir(oldTree *Tree, opts *DiffOptions) (*Diff, error) {
@@ -643,6 +663,7 @@ func (v *Repository) DiffTreeToWorkdir(oldTree *Tree, opts *DiffOptions) (*Diff,
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_diff_tree_to_workdir(&diffPtr, v.ptr, oldPtr, copts)
+	runtime.KeepAlive(oldTree)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -650,7 +671,7 @@ func (v *Repository) DiffTreeToWorkdir(oldTree *Tree, opts *DiffOptions) (*Diff,
 	if notifyData != nil && notifyData.Diff != nil {
 		return notifyData.Diff, nil
 	}
-	return newDiffFromC(diffPtr), nil
+	return newDiffFromC(diffPtr, v), nil
 }
 
 func (v *Repository) DiffTreeToIndex(oldTree *Tree, index *Index, opts *DiffOptions) (*Diff, error) {
@@ -673,6 +694,8 @@ func (v *Repository) DiffTreeToIndex(oldTree *Tree, index *Index, opts *DiffOpti
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_diff_tree_to_index(&diffPtr, v.ptr, oldPtr, indexPtr, copts)
+	runtime.KeepAlive(oldTree)
+	runtime.KeepAlive(index)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -680,7 +703,7 @@ func (v *Repository) DiffTreeToIndex(oldTree *Tree, index *Index, opts *DiffOpti
 	if notifyData != nil && notifyData.Diff != nil {
 		return notifyData.Diff, nil
 	}
-	return newDiffFromC(diffPtr), nil
+	return newDiffFromC(diffPtr, v), nil
 }
 
 func (v *Repository) DiffTreeToWorkdirWithIndex(oldTree *Tree, opts *DiffOptions) (*Diff, error) {
@@ -698,6 +721,7 @@ func (v *Repository) DiffTreeToWorkdirWithIndex(oldTree *Tree, opts *DiffOptions
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_diff_tree_to_workdir_with_index(&diffPtr, v.ptr, oldPtr, copts)
+	runtime.KeepAlive(oldTree)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -705,7 +729,7 @@ func (v *Repository) DiffTreeToWorkdirWithIndex(oldTree *Tree, opts *DiffOptions
 	if notifyData != nil && notifyData.Diff != nil {
 		return notifyData.Diff, nil
 	}
-	return newDiffFromC(diffPtr), nil
+	return newDiffFromC(diffPtr, v), nil
 }
 
 func (v *Repository) DiffIndexToWorkdir(index *Index, opts *DiffOptions) (*Diff, error) {
@@ -723,6 +747,7 @@ func (v *Repository) DiffIndexToWorkdir(index *Index, opts *DiffOptions) (*Diff,
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_diff_index_to_workdir(&diffPtr, v.ptr, indexPtr, copts)
+	runtime.KeepAlive(index)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -730,7 +755,7 @@ func (v *Repository) DiffIndexToWorkdir(index *Index, opts *DiffOptions) (*Diff,
 	if notifyData != nil && notifyData.Diff != nil {
 		return notifyData.Diff, nil
 	}
-	return newDiffFromC(diffPtr), nil
+	return newDiffFromC(diffPtr, v), nil
 }
 
 // DiffBlobs performs a diff between two arbitrary blobs. You can pass
@@ -773,6 +798,8 @@ func DiffBlobs(oldBlob *Blob, oldAsPath string, newBlob *Blob, newAsPath string,
 	defer runtime.UnlockOSThread()
 
 	ecode := C._go_git_diff_blobs(oldBlobPtr, oldBlobPath, newBlobPtr, newBlobPath, copts, 1, intHunks, intLines, handle)
+	runtime.KeepAlive(oldBlob)
+	runtime.KeepAlive(newBlob)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}

--- a/git.go
+++ b/git.go
@@ -232,6 +232,7 @@ func ShortenOids(ids []*Oid, minlen int) (int, error) {
 			return int(ret), MakeGitError(ret)
 		}
 	}
+	runtime.KeepAlive(ids)
 	return int(ret), nil
 }
 

--- a/graph.go
+++ b/graph.go
@@ -13,6 +13,9 @@ func (repo *Repository) DescendantOf(commit, ancestor *Oid) (bool, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_graph_descendant_of(repo.ptr, commit.toC(), ancestor.toC())
+	runtime.KeepAlive(repo)
+	runtime.KeepAlive(commit)
+	runtime.KeepAlive(ancestor)
 	if ret < 0 {
 		return false, MakeGitError(ret)
 	}
@@ -28,6 +31,9 @@ func (repo *Repository) AheadBehind(local, upstream *Oid) (ahead, behind int, er
 	var behindT C.size_t
 
 	ret := C.git_graph_ahead_behind(&aheadT, &behindT, repo.ptr, local.toC(), upstream.toC())
+	runtime.KeepAlive(repo)
+	runtime.KeepAlive(local)
+	runtime.KeepAlive(upstream)
 	if ret < 0 {
 		return 0, 0, MakeGitError(ret)
 	}

--- a/ignore.go
+++ b/ignore.go
@@ -17,6 +17,7 @@ func (v *Repository) AddIgnoreRule(rules string) error {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_ignore_add_rule(v.ptr, crules)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -28,6 +29,7 @@ func (v *Repository) ClearInternalIgnoreRules() error {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_ignore_clear_internal_rules(v.ptr)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -44,6 +46,7 @@ func (v *Repository) IsPathIgnored(path string) (bool, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_ignore_path_is_ignored(&ignored, v.ptr, cpath)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return false, MakeGitError(ret)
 	}

--- a/object.go
+++ b/object.go
@@ -46,7 +46,9 @@ func (t ObjectType) String() string {
 }
 
 func (o *Object) Id() *Oid {
-	return newOidFromC(C.git_object_id(o.ptr))
+	ret := newOidFromC(C.git_object_id(o.ptr))
+	runtime.KeepAlive(o)
+	return ret
 }
 
 func (o *Object) ShortId() (string, error) {
@@ -56,6 +58,7 @@ func (o *Object) ShortId() (string, error) {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_object_short_id(&resultBuf, o.ptr)
+	runtime.KeepAlive(o)
 	if ecode < 0 {
 		return "", MakeGitError(ecode)
 	}
@@ -64,15 +67,19 @@ func (o *Object) ShortId() (string, error) {
 }
 
 func (o *Object) Type() ObjectType {
-	return ObjectType(C.git_object_type(o.ptr))
+	ret := ObjectType(C.git_object_type(o.ptr))
+	runtime.KeepAlive(o)
+	return ret
 }
 
 // Owner returns a weak reference to the repository which owns this
 // object. This won't keep the underlying repository alive.
 func (o *Object) Owner() *Repository {
-	return &Repository{
+	ret := &Repository{
 		ptr: C.git_object_owner(o.ptr),
 	}
+	runtime.KeepAlive(o)
+	return ret
 }
 
 func dupObject(obj *Object, kind ObjectType) (*C.git_object, error) {
@@ -85,7 +92,9 @@ func dupObject(obj *Object, kind ObjectType) (*C.git_object, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if err := C.git_object_dup(&cobj, obj.ptr); err < 0 {
+	err := C.git_object_dup(&cobj, obj.ptr)
+	runtime.KeepAlive(obj)
+	if err < 0 {
 		return nil, MakeGitError(err)
 	}
 
@@ -203,7 +212,9 @@ func (o *Object) Peel(t ObjectType) (*Object, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if err := C.git_object_peel(&cobj, o.ptr, C.git_otype(t)); err < 0 {
+	err := C.git_object_peel(&cobj, o.ptr, C.git_otype(t))
+	runtime.KeepAlive(o)
+	if err < 0 {
 		return nil, MakeGitError(err)
 	}
 

--- a/patch.go
+++ b/patch.go
@@ -47,6 +47,7 @@ func (patch *Patch) String() (string, error) {
 	var buf C.git_buf
 
 	ecode := C.git_patch_to_buf(&buf, patch.ptr)
+	runtime.KeepAlive(patch)
 	if ecode < 0 {
 		return "", MakeGitError(ecode)
 	}
@@ -83,6 +84,8 @@ func (v *Repository) PatchFromBuffers(oldPath, newPath string, oldBuf, newBuf []
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_patch_from_buffers(&patchPtr, oldPtr, C.size_t(len(oldBuf)), cOldPath, newPtr, C.size_t(len(newBuf)), cNewPath, copts)
+	runtime.KeepAlive(oldBuf)
+	runtime.KeepAlive(newBuf)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}

--- a/refdb.go
+++ b/refdb.go
@@ -14,6 +14,7 @@ import (
 
 type Refdb struct {
 	ptr *C.git_refdb
+	r   *Repository
 }
 
 type RefdbBackend struct {
@@ -21,16 +22,17 @@ type RefdbBackend struct {
 }
 
 func (v *Repository) NewRefdb() (refdb *Refdb, err error) {
-	refdb = new(Refdb)
+	var ptr *C.git_refdb
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_refdb_new(&refdb.ptr, v.ptr)
+	ret := C.git_refdb_new(&ptr, v.ptr)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
 
+	refdb = &Refdb{ptr: ptr, r: v}
 	runtime.SetFinalizer(refdb, (*Refdb).Free)
 	return refdb, nil
 }
@@ -45,6 +47,8 @@ func (v *Refdb) SetBackend(backend *RefdbBackend) (err error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_refdb_set_backend(v.ptr, backend.ptr)
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(backend)
 	if ret < 0 {
 		backend.Free()
 		return MakeGitError(ret)
@@ -53,5 +57,6 @@ func (v *Refdb) SetBackend(backend *RefdbBackend) (err error) {
 }
 
 func (v *RefdbBackend) Free() {
+	runtime.SetFinalizer(v, nil)
 	C._go_git_refdb_backend_free(v.ptr)
 }

--- a/repository.go
+++ b/repository.go
@@ -120,6 +120,7 @@ func NewRepositoryWrapOdb(odb *Odb) (repo *Repository, err error) {
 
 	var ptr *C.git_repository
 	ret := C.git_repository_wrap_odb(&ptr, odb.ptr)
+	runtime.KeepAlive(odb)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}

--- a/repository.go
+++ b/repository.go
@@ -160,12 +160,11 @@ func (v *Repository) Index() (*Index, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_index(&ptr, v.ptr)
-	runtime.KeepAlive(v)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
 
-	return newIndexFromC(ptr), nil
+	return newIndexFromC(ptr, v), nil
 }
 
 func (v *Repository) lookupType(id *Oid, t ObjectType) (*Object, error) {

--- a/repository.go
+++ b/repository.go
@@ -129,6 +129,7 @@ func NewRepositoryWrapOdb(odb *Odb) (repo *Repository, err error) {
 
 func (v *Repository) SetRefdb(refdb *Refdb) {
 	C.git_repository_set_refdb(v.ptr, refdb.ptr)
+	runtime.KeepAlive(v)
 }
 
 func (v *Repository) Free() {
@@ -143,6 +144,7 @@ func (v *Repository) Config() (*Config, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_config(&config.ptr, v.ptr)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -158,6 +160,7 @@ func (v *Repository) Index() (*Index, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_index(&ptr, v.ptr)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -172,6 +175,7 @@ func (v *Repository) lookupType(id *Oid, t ObjectType) (*Object, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_object_lookup(&ptr, v.ptr, id.toC(), C.git_otype(t))
+	runtime.KeepAlive(id)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -241,6 +245,7 @@ func (v *Repository) SetHead(refname string) error {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_repository_set_head(v.ptr, cname)
+	runtime.KeepAlive(v)
 	if ecode != 0 {
 		return MakeGitError(ecode)
 	}
@@ -252,6 +257,8 @@ func (v *Repository) SetHeadDetached(id *Oid) error {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_repository_set_head_detached(v.ptr, id.toC())
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(id)
 	if ecode != 0 {
 		return MakeGitError(ecode)
 	}
@@ -263,6 +270,7 @@ func (v *Repository) IsHeadDetached() (bool, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_head_detached(v.ptr)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return false, MakeGitError(ret)
 	}
@@ -275,6 +283,7 @@ func (v *Repository) IsHeadUnborn() (bool, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_head_unborn(v.ptr)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return false, MakeGitError(ret)
 	}
@@ -286,6 +295,7 @@ func (v *Repository) IsEmpty() (bool, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_is_empty(v.ptr)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return false, MakeGitError(ret)
 	}
@@ -298,6 +308,7 @@ func (v *Repository) IsShallow() (bool, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_repository_is_shallow(v.ptr)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return false, MakeGitError(ret)
 	}
@@ -368,6 +379,9 @@ func (v *Repository) CreateCommit(
 		authorSig, committerSig,
 		nil, cmsg, tree.cast_ptr, C.size_t(nparents), parentsarg)
 
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(oid)
+	runtime.KeepAlive(parents)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -391,7 +405,9 @@ func (v *Repository) Odb() (odb *Odb, err error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if ret := C.git_repository_odb(&odb.ptr, v.ptr); ret < 0 {
+	ret := C.git_repository_odb(&odb.ptr, v.ptr)
+	runtime.KeepAlive(v)
+	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
 
@@ -400,15 +416,21 @@ func (v *Repository) Odb() (odb *Odb, err error) {
 }
 
 func (repo *Repository) Path() string {
-	return C.GoString(C.git_repository_path(repo.ptr))
+	s := C.GoString(C.git_repository_path(repo.ptr))
+	runtime.KeepAlive(repo)
+	return s
 }
 
 func (repo *Repository) IsBare() bool {
-	return C.git_repository_is_bare(repo.ptr) != 0
+	ret := C.git_repository_is_bare(repo.ptr) != 0
+	runtime.KeepAlive(repo)
+	return ret
 }
 
 func (repo *Repository) Workdir() string {
-	return C.GoString(C.git_repository_workdir(repo.ptr))
+	s := C.GoString(C.git_repository_workdir(repo.ptr))
+	runtime.KeepAlive(repo)
+	return s
 }
 
 func (repo *Repository) SetWorkdir(workdir string, updateGitlink bool) error {
@@ -421,6 +443,7 @@ func (repo *Repository) SetWorkdir(workdir string, updateGitlink bool) error {
 	if ret := C.git_repository_set_workdir(repo.ptr, cstr, cbool(updateGitlink)); ret < 0 {
 		return MakeGitError(ret)
 	}
+	runtime.KeepAlive(repo)
 
 	return nil
 }
@@ -434,6 +457,7 @@ func (v *Repository) TreeBuilder() (*TreeBuilder, error) {
 	if ret := C.git_treebuilder_new(&bld.ptr, v.ptr, nil); ret < 0 {
 		return nil, MakeGitError(ret)
 	}
+
 	runtime.SetFinalizer(bld, (*TreeBuilder).Free)
 
 	bld.repo = v
@@ -474,7 +498,10 @@ func (r *Repository) State() RepositoryState {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	return RepositoryState(C.git_repository_state(r.ptr))
+	ret := RepositoryState(C.git_repository_state(r.ptr))
+	runtime.KeepAlive(r)
+
+	return ret
 }
 
 func (r *Repository) StateCleanup() error {
@@ -482,18 +509,22 @@ func (r *Repository) StateCleanup() error {
 	defer runtime.UnlockOSThread()
 
 	cErr := C.git_repository_state_cleanup(r.ptr)
+	runtime.KeepAlive(r)
 	if cErr < 0 {
 		return MakeGitError(cErr)
 	}
 	return nil
 }
+
 func (r *Repository) AddGitIgnoreRules(rules string) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	crules := C.CString(rules)
 	defer C.free(unsafe.Pointer(crules))
-	if ret := C.git_ignore_add_rule(r.ptr, crules); ret < 0 {
+	ret := C.git_ignore_add_rule(r.ptr, crules)
+	runtime.KeepAlive(r)
+	if ret < 0 {
 		return MakeGitError(ret)
 	}
 	return nil
@@ -503,7 +534,9 @@ func (r *Repository) ClearGitIgnoreRules() error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if ret := C.git_ignore_clear_internal_rules(r.ptr); ret < 0 {
+	ret := C.git_ignore_clear_internal_rules(r.ptr)
+	runtime.KeepAlive(r)
+	if ret < 0 {
 		return MakeGitError(ret)
 	}
 	return nil

--- a/signature.go
+++ b/signature.go
@@ -63,6 +63,7 @@ func (repo *Repository) DefaultSignature() (*Signature, error) {
 	defer runtime.UnlockOSThread()
 
 	cErr := C.git_signature_default(&out, repo.ptr)
+	runtime.KeepAlive(repo)
 	if cErr < 0 {
 		return nil, MakeGitError(cErr)
 	}

--- a/stash.go
+++ b/stash.go
@@ -63,7 +63,7 @@ func (c *StashCollection) Save(
 	ret := C.git_stash_save(
 		oid.toC(), c.repo.ptr,
 		stasherC, messageC, C.uint32_t(flags))
-
+	runtime.KeepAlive(c)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -228,6 +228,7 @@ func (c *StashCollection) Apply(index int, opts StashApplyOptions) error {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_stash_apply(c.repo.ptr, C.size_t(index), optsC)
+	runtime.KeepAlive(c)
 	if ret == C.GIT_EUSER {
 		return progressData.Error
 	}
@@ -282,6 +283,7 @@ func (c *StashCollection) Foreach(callback StashCallback) error {
 	defer runtime.UnlockOSThread()
 
 	ret := C._go_git_stash_foreach(c.repo.ptr, handle)
+	runtime.KeepAlive(c)
 	if ret == C.GIT_EUSER {
 		return data.Error
 	}
@@ -303,6 +305,7 @@ func (c *StashCollection) Drop(index int) error {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_stash_drop(c.repo.ptr, C.size_t(index))
+	runtime.KeepAlive(c)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -328,6 +331,7 @@ func (c *StashCollection) Pop(index int, opts StashApplyOptions) error {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_stash_pop(c.repo.ptr, C.size_t(index), optsC)
+	runtime.KeepAlive(c)
 	if ret == C.GIT_EUSER {
 		return progressData.Error
 	}

--- a/status.go
+++ b/status.go
@@ -55,15 +55,17 @@ func statusEntryFromC(statusEntry *C.git_status_entry) StatusEntry {
 
 type StatusList struct {
 	ptr *C.git_status_list
+	r   *Repository
 }
 
-func newStatusListFromC(ptr *C.git_status_list) *StatusList {
+func newStatusListFromC(ptr *C.git_status_list, r *Repository) *StatusList {
 	if ptr == nil {
 		return nil
 	}
 
 	statusList := &StatusList{
 		ptr: ptr,
+		r:   r,
 	}
 
 	runtime.SetFinalizer(statusList, (*StatusList).Free)
@@ -84,14 +86,20 @@ func (statusList *StatusList) ByIndex(index int) (StatusEntry, error) {
 		return StatusEntry{}, ErrInvalid
 	}
 	ptr := C.git_status_byindex(statusList.ptr, C.size_t(index))
-	return statusEntryFromC(ptr), nil
+	entry := statusEntryFromC(ptr)
+	runtime.KeepAlive(statusList)
+
+	return entry, nil
 }
 
 func (statusList *StatusList) EntryCount() (int, error) {
 	if statusList.ptr == nil {
 		return -1, ErrInvalid
 	}
-	return int(C.git_status_list_entrycount(statusList.ptr)), nil
+	ret := int(C.git_status_list_entrycount(statusList.ptr))
+	runtime.KeepAlive(statusList)
+
+	return ret, nil
 }
 
 type StatusOpt int
@@ -161,7 +169,7 @@ func (v *Repository) StatusList(opts *StatusOptions) (*StatusList, error) {
 		return nil, MakeGitError(ret)
 	}
 
-	return newStatusListFromC(ptr), nil
+	return newStatusListFromC(ptr, v), nil
 }
 
 func (v *Repository) StatusFile(path string) (Status, error) {
@@ -173,6 +181,7 @@ func (v *Repository) StatusFile(path string) (Status, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_status_file(&statusFlags, v.ptr, cPath)
+	runtime.KeepAlive(v)
 	if ret < 0 {
 		return 0, MakeGitError(ret)
 	}

--- a/tag.go
+++ b/tag.go
@@ -18,22 +18,28 @@ type Tag struct {
 }
 
 func (t Tag) Message() string {
-	return C.GoString(C.git_tag_message(t.cast_ptr))
+	ret := C.GoString(C.git_tag_message(t.cast_ptr))
+	runtime.KeepAlive(t)
+	return ret
 }
 
 func (t Tag) Name() string {
-	return C.GoString(C.git_tag_name(t.cast_ptr))
+	ret := C.GoString(C.git_tag_name(t.cast_ptr))
+	runtime.KeepAlive(t)
+	return ret
 }
 
 func (t Tag) Tagger() *Signature {
 	cast_ptr := C.git_tag_tagger(t.cast_ptr)
-	return newSignatureFromC(cast_ptr)
+	ret := newSignatureFromC(cast_ptr)
+	runtime.KeepAlive(t)
+	return ret
 }
 
 func (t Tag) Target() *Object {
 	var ptr *C.git_object
 	ret := C.git_tag_target(&ptr, t.cast_ptr)
-
+	runtime.KeepAlive(t)
 	if ret != 0 {
 		return nil
 	}
@@ -42,11 +48,15 @@ func (t Tag) Target() *Object {
 }
 
 func (t Tag) TargetId() *Oid {
-	return newOidFromC(C.git_tag_target_id(t.cast_ptr))
+	ret := newOidFromC(C.git_tag_target_id(t.cast_ptr))
+	runtime.KeepAlive(t)
+	return ret
 }
 
 func (t Tag) TargetType() ObjectType {
-	return ObjectType(C.git_tag_target_type(t.cast_ptr))
+	ret := ObjectType(C.git_tag_target_type(t.cast_ptr))
+	runtime.KeepAlive(t)
+	return ret
 }
 
 type TagsCollection struct {
@@ -76,6 +86,7 @@ func (c *TagsCollection) Create(
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_tag_create(oid.toC(), c.repo.ptr, cname, ctarget, taggerSig, cmessage, 0)
+	runtime.KeepAlive(c)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -91,6 +102,7 @@ func (c *TagsCollection) Remove(name string) error {
 	defer C.free(unsafe.Pointer(cname))
 
 	ret := C.git_tag_delete(c.repo.ptr, cname)
+	runtime.KeepAlive(c)
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -123,6 +135,7 @@ func (c *TagsCollection) CreateLightweight(name string, commit *Commit, force bo
 	defer runtime.UnlockOSThread()
 
 	err := C.git_tag_create_lightweight(oid.toC(), c.repo.ptr, cname, ctarget, cbool(force))
+	runtime.KeepAlive(c)
 	if err < 0 {
 		return nil, MakeGitError(err)
 	}
@@ -139,6 +152,7 @@ func (c *TagsCollection) List() ([]string, error) {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_tag_list(&strC, c.repo.ptr)
+	runtime.KeepAlive(c)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -162,6 +176,7 @@ func (c *TagsCollection) ListWithMatch(pattern string) ([]string, error) {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_tag_list_match(&strC, patternC, c.repo.ptr)
+	runtime.KeepAlive(c)
 	if ecode < 0 {
 		return nil, MakeGitError(ecode)
 	}
@@ -215,6 +230,7 @@ func (c *TagsCollection) Foreach(callback TagForeachCallback) error {
 	defer runtime.UnlockOSThread()
 
 	err := C._go_git_tag_foreach(c.repo.ptr, handle)
+	runtime.KeepAlive(c)
 	if err == C.GIT_EUSER {
 		return data.err
 	}

--- a/tree.go
+++ b/tree.go
@@ -48,6 +48,7 @@ func (t Tree) EntryByName(filename string) *TreeEntry {
 	defer C.free(unsafe.Pointer(cname))
 
 	entry := C.git_tree_entry_byname(t.cast_ptr, cname)
+	runtime.KeepAlive(t)
 	if entry == nil {
 		return nil
 	}
@@ -66,6 +67,8 @@ func (t Tree) EntryById(id *Oid) *TreeEntry {
 	defer runtime.UnlockOSThread()
 
 	entry := C.git_tree_entry_byid(t.cast_ptr, id.toC())
+	runtime.KeepAlive(t)
+	runtime.KeepAlive(id)
 	if entry == nil {
 		return nil
 	}
@@ -84,6 +87,7 @@ func (t Tree) EntryByPath(path string) (*TreeEntry, error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_tree_entry_bypath(&entry, t.cast_ptr, cpath)
+	runtime.KeepAlive(t)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -94,6 +98,7 @@ func (t Tree) EntryByPath(path string) (*TreeEntry, error) {
 
 func (t Tree) EntryByIndex(index uint64) *TreeEntry {
 	entry := C.git_tree_entry_byindex(t.cast_ptr, C.size_t(index))
+	runtime.KeepAlive(t)
 	if entry == nil {
 		return nil
 	}
@@ -103,6 +108,7 @@ func (t Tree) EntryByIndex(index uint64) *TreeEntry {
 
 func (t Tree) EntryCount() uint64 {
 	num := C.git_tree_entrycount(t.cast_ptr)
+	runtime.KeepAlive(t)
 	return uint64(num)
 }
 
@@ -132,7 +138,7 @@ func (t Tree) Walk(callback TreeWalkCallback) error {
 		C.GIT_TREEWALK_PRE,
 		ptr,
 	)
-
+	runtime.KeepAlive(t)
 	if err < 0 {
 		return MakeGitError(err)
 	}
@@ -158,6 +164,8 @@ func (v *TreeBuilder) Insert(filename string, id *Oid, filemode Filemode) error 
 	defer runtime.UnlockOSThread()
 
 	err := C.git_treebuilder_insert(nil, v.ptr, cfilename, id.toC(), C.git_filemode_t(filemode))
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(id)
 	if err < 0 {
 		return MakeGitError(err)
 	}
@@ -173,6 +181,7 @@ func (v *TreeBuilder) Remove(filename string) error {
 	defer runtime.UnlockOSThread()
 
 	err := C.git_treebuilder_remove(v.ptr, cfilename)
+	runtime.KeepAlive(v)
 	if err < 0 {
 		return MakeGitError(err)
 	}
@@ -187,7 +196,7 @@ func (v *TreeBuilder) Write() (*Oid, error) {
 	defer runtime.UnlockOSThread()
 
 	err := C.git_treebuilder_write(oid.toC(), v.ptr)
-
+	runtime.KeepAlive(v)
 	if err < 0 {
 		return nil, MakeGitError(err)
 	}

--- a/walk.go
+++ b/walk.go
@@ -34,6 +34,7 @@ func revWalkFromC(repo *Repository, c *C.git_revwalk) *RevWalk {
 
 func (v *RevWalk) Reset() {
 	C.git_revwalk_reset(v.ptr)
+	runtime.KeepAlive(v)
 }
 
 func (v *RevWalk) Push(id *Oid) error {
@@ -41,6 +42,8 @@ func (v *RevWalk) Push(id *Oid) error {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_revwalk_push(v.ptr, id.toC())
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(id)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -55,6 +58,7 @@ func (v *RevWalk) PushGlob(glob string) error {
 	defer C.free(unsafe.Pointer(cstr))
 
 	ecode := C.git_revwalk_push_glob(v.ptr, cstr)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -69,6 +73,7 @@ func (v *RevWalk) PushRange(r string) error {
 	defer C.free(unsafe.Pointer(cstr))
 
 	ecode := C.git_revwalk_push_range(v.ptr, cstr)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -83,6 +88,7 @@ func (v *RevWalk) PushRef(r string) error {
 	defer C.free(unsafe.Pointer(cstr))
 
 	ecode := C.git_revwalk_push_ref(v.ptr, cstr)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -94,6 +100,7 @@ func (v *RevWalk) PushHead() (err error) {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_revwalk_push_head(v.ptr)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		err = MakeGitError(ecode)
 	}
@@ -105,6 +112,8 @@ func (v *RevWalk) Hide(id *Oid) error {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_revwalk_hide(v.ptr, id.toC())
+	runtime.KeepAlive(v)
+	runtime.KeepAlive(id)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -119,6 +128,7 @@ func (v *RevWalk) HideGlob(glob string) error {
 	defer C.free(unsafe.Pointer(cstr))
 
 	ecode := C.git_revwalk_hide_glob(v.ptr, cstr)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -133,6 +143,7 @@ func (v *RevWalk) HideRef(r string) error {
 	defer C.free(unsafe.Pointer(cstr))
 
 	ecode := C.git_revwalk_hide_ref(v.ptr, cstr)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		return MakeGitError(ecode)
 	}
@@ -144,6 +155,7 @@ func (v *RevWalk) HideHead() (err error) {
 	defer runtime.UnlockOSThread()
 
 	ecode := C.git_revwalk_hide_head(v.ptr)
+	runtime.KeepAlive(v)
 	if ecode < 0 {
 		err = MakeGitError(ecode)
 	}
@@ -155,6 +167,7 @@ func (v *RevWalk) Next(id *Oid) (err error) {
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_revwalk_next(id.toC(), v.ptr)
+	runtime.KeepAlive(v)
 	switch {
 	case ret < 0:
 		err = MakeGitError(ret)
@@ -192,14 +205,15 @@ func (v *RevWalk) Iterate(fun RevWalkIterator) (err error) {
 
 func (v *RevWalk) SimplifyFirstParent() {
 	C.git_revwalk_simplify_first_parent(v.ptr)
+	runtime.KeepAlive(v)
 }
 
 func (v *RevWalk) Sorting(sm SortType) {
 	C.git_revwalk_sorting(v.ptr, C.uint(sm))
+	runtime.KeepAlive(v)
 }
 
 func (v *RevWalk) Free() {
-
 	runtime.SetFinalizer(v, nil)
 	C.git_revwalk_free(v.ptr)
 }


### PR DESCRIPTION
Newer Go runtimes' GC is particularly eager and doesn't even consider the receiver as a reference. Thus in order for structs wrapping the pointers not to be freed while in the middle of us using them in a function call, we must make sure that the wrapping struct is kept alive until after we return from.

This seems to be the cause of #352, #334 and #356 and this should fix the other places where this might happen.