### PR TITLE
Deduplicate Makefile static target and add thread locking check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,9 @@ install: build-libgit2
 build-libgit2:
 	./script/build-libgit2-static.sh
 
-static: build-libgit2
-	go run script/check-MakeGitError-thread-lock.go
-	go test --tags "static" ./...
-
 install-static: build-libgit2
 	go install --tags "static" ./...
 
 test-static: build-libgit2
+	go run script/check-MakeGitError-thread-lock.go
 	go test --tags "static" ./...


### PR DESCRIPTION
It turns out we had been running CI without performing the thread locking check.