### PR TITLE
rebase: correct the return values for CurrentOperationIndex

### DIFF
--- a/rebase_test.go
+++ b/rebase_test.go
@@ -182,7 +182,7 @@ func performRebaseOnto(repo *Repository, branch string) (*Rebase, error) {
 
 	// Check no operation has been started yet
 	rebaseOperationIndex, err := rebase.CurrentOperationIndex()
-	if err == nil {
+	if rebaseOperationIndex != RebaseNoOperation && err != ErrRebaseNoOperation {
 		return nil, errors.New("No operation should have been started yet")
 	}
 


### PR DESCRIPTION
We were incorectly reporting `C.GIT_REBASE_NO_OPERATION` as an error code when
it is none. We should instead return it as the value. The compiler doesn't seem
to actually look at the sizes so instead we must recreate the value ourselves
with `^uint(0)`.

The error return is kept for API compatibility but should go away eventually.

This supersedes #385 