### PR TITLE
clone_checkout_strategy removed

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -15,7 +15,6 @@ import (
 type SubmoduleUpdateOptions struct {
 	*CheckoutOpts
 	*FetchOptions
-	CloneCheckoutStrategy CheckoutStrategy
 }
 
 // Submodule
@@ -369,7 +368,6 @@ func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *S
 
 	populateCheckoutOpts(&ptr.checkout_opts, opts.CheckoutOpts)
 	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
-	ptr.clone_checkout_strategy = C.uint(opts.CloneCheckoutStrategy)
 
 	return nil
 }


### PR DESCRIPTION
There is a breaking API change in [libgit2 0.26](https://github.com/libgit2/libgit2/releases/tag/v0.26.0).

I guess `CloneCheckoutStrategy` also can be removed.