### PR TITLE
Remove unnecessary CloneCheckoutStrategy option

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -15,7 +15,6 @@ import (
 type SubmoduleUpdateOptions struct {
 	*CheckoutOpts
 	*FetchOptions
-	CloneCheckoutStrategy CheckoutStrategy
 }
 
 // Submodule
@@ -369,7 +368,6 @@ func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *S
 
 	populateCheckoutOpts(&ptr.checkout_opts, opts.CheckoutOpts)
 	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
-	ptr.clone_checkout_strategy = C.uint(opts.CloneCheckoutStrategy)
 
 	return nil
 }


### PR DESCRIPTION
Libgit2 doesn't have that option anymore in v26 as seen in [libgit2 issue 3784](https://github.com/libgit2/libgit2/issues/3784).
In fact, this is the reason git2go couldn't be built if libgit2 v26 is installed.