### PR TITLE
align to libgit2 v0.26.0 api changes:

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -369,7 +369,6 @@ func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *S
 
 	populateCheckoutOpts(&ptr.checkout_opts, opts.CheckoutOpts)
 	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
-	ptr.clone_checkout_strategy = C.uint(opts.CloneCheckoutStrategy)
 
 	return nil
 }


### PR DESCRIPTION
`clone_checkout_strategy` has been removed from libgit2. The checkout strategy used to clone will
be the same strategy specified in `checkout_opts`