### PR TITLE
merge: add missing MergeFileFlag constants

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -344,9 +344,29 @@ type MergeFileFlags int
 const (
 	MergeFileDefault MergeFileFlags = C.GIT_MERGE_FILE_DEFAULT
 
-	MergeFileStyleMerge         MergeFileFlags = C.GIT_MERGE_FILE_STYLE_MERGE
-	MergeFileStyleDiff          MergeFileFlags = C.GIT_MERGE_FILE_STYLE_DIFF3
+	// Create standard conflicted merge files
+	MergeFileStyleMerge MergeFileFlags = C.GIT_MERGE_FILE_STYLE_MERGE
+
+	// Create diff3-style files
+	MergeFileStyleDiff MergeFileFlags = C.GIT_MERGE_FILE_STYLE_DIFF3
+
+	// Condense non-alphanumeric regions for simplified diff file
 	MergeFileStyleSimplifyAlnum MergeFileFlags = C.GIT_MERGE_FILE_SIMPLIFY_ALNUM
+
+	// Ignore all whitespace
+	MergeFileIgnoreWhitespace MergeFileFlags = C.GIT_MERGE_FILE_IGNORE_WHITESPACE
+
+	// Ignore changes in amount of whitespace
+	MergeFileIgnoreWhitespaceChange MergeFileFlags = C.GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE
+
+	// Ignore whitespace at end of line
+	MergeFileIgnoreWhitespaceEOL MergeFileFlags = C.GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL
+
+	// Use the "patience diff" algorithm
+	MergeFileDiffPatience MergeFileFlags = C.GIT_MERGE_FILE_DIFF_PATIENCE
+
+	// Take extra time to find minimal diff
+	MergeFileDiffMinimal MergeFileFlags = C.GIT_MERGE_FILE_DIFF_MINIMAL
 )
 
 type MergeFileOptions struct {


### PR DESCRIPTION
While we're here, pull in comments as well.
While one can pop back and forth between godoc and libgit2 refs,
it's much nicer to have it in one place.

Note that MergeFileStyleSimplifyAlnum probably should have been called
merely MergeFileSimplifyAlnum (no "Style"). It's probably not worth
breaking backwards compatibility to fix it, but we avoid the mistake
going forwards.