### PR TITLE
vendor: update libgit2 to v0.27.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.7
   - 1.8
   - 1.9
-  - 1.10
+  - "1.10"
   - tip
 
 script: make test-static


### PR DESCRIPTION
This covers CVE-2018-11235 and forbids .gitmodules as symlinks.