### PR TITLE
static: use pkg-config exclusively when using it

### DIFF
--- a/git_static.go
+++ b/git_static.go
@@ -3,9 +3,8 @@
 package git
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/vendor/libgit2/include
-#cgo LDFLAGS: -L${SRCDIR}/vendor/libgit2/build/ -lgit2
-#cgo windows LDFLAGS: -lwinhttp
+#cgo windows CFLAGS: -I${SRCDIR}/vendor/libgit2/include
+#cgo windows LDFLAGS: -L${SRCDIR}/vendor/libgit2/build/ -lgit2 -lwinhttp
 #cgo !windows pkg-config: --static ${SRCDIR}/vendor/libgit2/build/libgit2.pc
 #include <git2.h>
 

--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -16,4 +16,4 @@ cmake -DTHREADSAFE=ON \
       -DCMAKE_INSTALL_PREFIX=../install \
       .. &&
 
-cmake --build .
+cmake --build . --target install


### PR DESCRIPTION
When using the static linking option on platforms that use pkg-config,
use ONLY pkg-config to get the CFLAGS and LDFLAGS. This prevents pulling
in dependencies and flags for any non-vendored version that may be
present on the host.

The main practical effect of this is that if someone doesn't need/want
any sort of remote access support at all they can completely disable
libcurl, libssh2, libssl, etc and produce a smaller/simpler binary and
greatly simplify their build-time dependencies. When done properly, the
generated pkg-config file will tell cgo everything it needs to know.

This also prevents confusion if there is a system copy of libgit2 that
is being given priority over the vendored build.