### PR TITLE
git2go: small fixes to odb module

### DIFF
--- a/odb.go
+++ b/odb.go
@@ -80,15 +80,19 @@ func (v *Odb) Exists(oid *Oid) bool {
 
 func (v *Odb) Write(data []byte, otype ObjectType) (oid *Oid, err error) {
 	oid = new(Oid)
-	var cptr unsafe.Pointer
-	if len(data) > 0 {
-		cptr = unsafe.Pointer(&data[0])
-	}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_odb_write(oid.toC(), v.ptr, cptr, C.size_t(len(data)), C.git_otype(otype))
+	var size C.size_t
+	if len(data) > 0 {
+		size = C.size_t(len(data))
+	} else {
+		data = []byte{0}
+		size = C.size_t(0)
+	}
+
+	ret := C.git_odb_write(oid.toC(), v.ptr, unsafe.Pointer(&data[0]), size, C.git_otype(otype))
 	runtime.KeepAlive(v)
 	if ret < 0 {
 		return nil, MakeGitError(ret)
@@ -164,13 +168,19 @@ func (v *Odb) ForEach(callback OdbForEachCallback) error {
 // Hash determines the object-ID (sha1) of a data buffer.
 func (v *Odb) Hash(data []byte, otype ObjectType) (oid *Oid, err error) {
 	oid = new(Oid)
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	ptr := unsafe.Pointer(header.Data)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_odb_hash(oid.toC(), ptr, C.size_t(header.Len), C.git_otype(otype))
+	var size C.size_t
+	if len(data) > 0 {
+		size = C.size_t(len(data))
+	} else {
+		data = []byte{0}
+		size = C.size_t(0)
+	}
+
+	ret := C.git_odb_hash(oid.toC(), unsafe.Pointer(&data[0]), size, C.git_otype(otype))
 	runtime.KeepAlive(data)
 	if ret < 0 {
 		return nil, MakeGitError(ret)

--- a/odb_test.go
+++ b/odb_test.go
@@ -1,12 +1,13 @@
 package git
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"testing"
 )
 
-func TestOdbReadHeader(t *testing.T) {
+func TestOdbRead(t *testing.T) {
 	t.Parallel()
 	repo := createTestRepo(t)
 	defer cleanupTestRepo(t, repo)
@@ -26,12 +27,26 @@ func TestOdbReadHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadHeader: %v", err)
 	}
-	
+
 	if sz != uint64(len(data)) {
 		t.Errorf("ReadHeader got size %d, want %d", sz, len(data))
 	}
 	if typ != ObjectBlob {
 		t.Errorf("ReadHeader got object type %s", typ)
+	}
+
+	obj, err := odb.Read(id)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(obj.Data(), data) {
+		t.Errorf("Read got wrong data")
+	}
+	if sz := obj.Len(); sz != uint64(len(data)) {
+		t.Errorf("Read got size %d, want %d", sz, len(data))
+	}
+	if typ := obj.Type(); typ != ObjectBlob {
+		t.Errorf("Read got object type %s", typ)
 	}
 }
 
@@ -82,14 +97,16 @@ committer John Doe <john@doe.com> 1390682018 +0000
 
 Initial commit.`
 
-	oid, error := odb.Hash([]byte(str), ObjectCommit)
-	checkFatal(t, error)
+	for _, data := range [][]byte{[]byte(str), doublePointerBytes()} {
+		oid, error := odb.Hash(data, ObjectCommit)
+		checkFatal(t, error)
 
-	coid, error := odb.Write([]byte(str), ObjectCommit)
-	checkFatal(t, error)
+		coid, error := odb.Write(data, ObjectCommit)
+		checkFatal(t, error)
 
-	if oid.Cmp(coid) != 0 {
-		t.Fatal("Hash and write Oids are different")
+		if oid.Cmp(coid) != 0 {
+			t.Fatal("Hash and write Oids are different")
+		}
 	}
 }
 


### PR DESCRIPTION
- Fix couple cgo issues in odb.Write() and odb.Hash(). This is the
  same issue - and same solution - as repo.CreateBlobFromBuffer()
  used to have.

- Add test for odb.Read()