### PR TITLE
Use git_buf_dispose() instead of git_buf_free()

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -208,7 +208,7 @@ func (repo *Repository) RemoteName(canonicalBranchName string) (string, error) {
 	if ret < 0 {
 		return "", MakeGitError(ret)
 	}
-	defer C.git_buf_free(&nameBuf)
+	defer C.git_buf_dispose(&nameBuf)
 
 	return C.GoString(nameBuf.ptr), nil
 }
@@ -256,7 +256,7 @@ func (repo *Repository) UpstreamName(canonicalBranchName string) (string, error)
 	if ret < 0 {
 		return "", MakeGitError(ret)
 	}
-	defer C.git_buf_free(&nameBuf)
+	defer C.git_buf_dispose(&nameBuf)
 
 	return C.GoString(nameBuf.ptr), nil
 }

--- a/commit.go
+++ b/commit.go
@@ -37,10 +37,10 @@ func (c *Commit) RawMessage() string {
 func (c *Commit) ExtractSignature() (string, string, error) {
 
 	var c_signed C.git_buf
-	defer C.git_buf_free(&c_signed)
+	defer C.git_buf_dispose(&c_signed)
 
 	var c_signature C.git_buf
-	defer C.git_buf_free(&c_signature)
+	defer C.git_buf_dispose(&c_signature)
 
 	oid := c.Id()
 	repo := C.git_commit_owner(c.cast_ptr)

--- a/config.go
+++ b/config.go
@@ -134,7 +134,7 @@ func (c *Config) LookupString(name string) (string, error) {
 	if ret < 0 {
 		return "", MakeGitError(ret)
 	}
-	defer C.git_buf_free(&valBuf)
+	defer C.git_buf_dispose(&valBuf)
 
 	return C.GoString(valBuf.ptr), nil
 }
@@ -390,7 +390,7 @@ func (iter *ConfigIterator) Free() {
 
 func ConfigFindGlobal() (string, error) {
 	var buf C.git_buf
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -405,7 +405,7 @@ func ConfigFindGlobal() (string, error) {
 
 func ConfigFindSystem() (string, error) {
 	var buf C.git_buf
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -420,7 +420,7 @@ func ConfigFindSystem() (string, error) {
 
 func ConfigFindXDG() (string, error) {
 	var buf C.git_buf
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -438,7 +438,7 @@ func ConfigFindXDG() (string, error) {
 // Look for the file in %PROGRAMDATA%\Git\config used by portable git.
 func ConfigFindProgramdata() (string, error) {
 	var buf C.git_buf
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/describe.go
+++ b/describe.go
@@ -212,7 +212,7 @@ func (result *DescribeResult) Format(opts *DescribeFormatOptions) (string, error
 	if ecode < 0 {
 		return "", MakeGitError(ecode)
 	}
-	defer C.git_buf_free(&resultBuf)
+	defer C.git_buf_dispose(&resultBuf)
 
 	return C.GoString(resultBuf.ptr), nil
 }

--- a/diff.go
+++ b/diff.go
@@ -246,7 +246,7 @@ const (
 func (stats *DiffStats) String(format DiffStatsFormat,
 	width uint) (string, error) {
 	buf := C.git_buf{}
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/git.go
+++ b/git.go
@@ -309,7 +309,7 @@ func Discover(start string, across_fs bool, ceiling_dirs []string) (string, erro
 	defer C.free(unsafe.Pointer(cstart))
 
 	var buf C.git_buf
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/note.go
+++ b/note.go
@@ -132,7 +132,7 @@ func (c *NoteCollection) DefaultRef() (string, error) {
 	}
 
 	ret := C.GoString(buf.ptr)
-	C.git_buf_free(&buf)
+	C.git_buf_dispose(&buf)
 
 	return ret, nil
 }

--- a/object.go
+++ b/object.go
@@ -67,7 +67,7 @@ func (o *Object) ShortId() (string, error) {
 	if ecode < 0 {
 		return "", MakeGitError(ecode)
 	}
-	defer C.git_buf_free(&resultBuf)
+	defer C.git_buf_dispose(&resultBuf)
 	return C.GoString(resultBuf.ptr), nil
 }
 

--- a/patch.go
+++ b/patch.go
@@ -51,7 +51,7 @@ func (patch *Patch) String() (string, error) {
 	if ecode < 0 {
 		return "", MakeGitError(ecode)
 	}
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	return C.GoString(buf.ptr), nil
 }

--- a/settings.go
+++ b/settings.go
@@ -31,7 +31,7 @@ import (
 
 func SearchPath(level ConfigLevel) (string, error) {
 	var buf C.git_buf
-	defer C.git_buf_free(&buf)
+	defer C.git_buf_dispose(&buf)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()


### PR DESCRIPTION
git_buf_free() is now deprecated. This change uses the new
git_buf_dispose(). It also updates `vendor/libgit2` to the latest
commit.