### PR TITLE
Fix Issue #461

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -63,3 +63,54 @@ func TestTreeBuilderInsert(t *testing.T) {
 		t.Fatalf("got oid %v, want %v", entry.Id, blobId)
 	}
 }
+
+func TestTreeWalk(t *testing.T) {
+	var entryName string = "testEntry"
+	var expect int = 9001
+	var found bool = false
+
+	t.Parallel()
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	_, treeID := seedTestRepo(t, repo)
+
+	tree, err := repo.LookupTree(treeID)
+	checkFatal(t, err)
+
+	treeBuilder, err := repo.TreeBuilderFromTree(tree)
+	checkFatal(t, err)
+
+	defer treeBuilder.Free()
+
+	odb, err := repo.Odb()
+	checkFatal(t, err)
+
+	blobId, err := odb.Write([]byte("hello, walk."), ObjectBlob)
+	checkFatal(t, err)
+
+	err = treeBuilder.Insert(entryName, blobId, FilemodeBlobExecutable)
+	checkFatal(t, err)
+
+	newTreeId, err := treeBuilder.Write()
+	checkFatal(t, err)
+
+	tree, err = repo.LookupTree(newTreeId)
+	checkFatal(t, err)
+
+	callback := func(e string, te *TreeEntry, ctx interface{}) int {
+		if ctx.(int) != expect {
+			t.Fatalf("Expected %d in all callback payloads", expect)
+		}
+		if te.Name == entryName {
+			found = true
+		}
+		return 0
+	}
+
+	tree.Walk(callback, expect)
+
+	if !found {
+		t.Fatalf("Expected `%s` in subTree", entryName)
+	}
+}


### PR DESCRIPTION
    Pass a callback context down to `git_tree_walk` instead of the
    callback pointer directly. This allows the `Walk` callback to
    more closely match that of libgit2 by attaching a callback
    payload.

    Additionally, add a unittest for tree.Walk() which verifies
    added tree entries and that the context data is valid.