### PR TITLE
Add index.Clear() to clear the index object

### DIFF
--- a/index.go
+++ b/index.go
@@ -145,6 +145,20 @@ func (v *Index) Path() string {
 	return ret
 }
 
+// Clear clears the index object in memory; changes must be explicitly
+// written to disk for them to take effect persistently
+func (v *Index) Clear() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	err := C.git_index_clear(v.ptr)
+	runtime.KeepAlive(v)
+	if err < 0 {
+		return MakeGitError(err)
+	}
+	return nil
+}
+
 // Add adds or replaces the given entry to the index, making a copy of
 // the data
 func (v *Index) Add(entry *IndexEntry) error {


### PR DESCRIPTION
Simple PR that adds `index.Clear()`, which does nothing more than calling [`git_index_clear`](https://github.com/libgit2/libgit2/blob/bea65980c7a42e34edfafbdc40b199ba7b2a564e/include/git2/index.h#L404).