### PR TITLE
Remove unused parameter in OpenOndisk #256

### DIFF
--- a/config.go
+++ b/config.go
@@ -344,7 +344,7 @@ func (c *Config) OpenLevel(parent *Config, level ConfigLevel) (*Config, error) {
 }
 
 // OpenOndisk creates a new config instance containing a single on-disk file
-func OpenOndisk(parent *Config, path string) (*Config, error) {
+func OpenOndisk(path string) (*Config, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 

--- a/config_test.go
+++ b/config_test.go
@@ -13,7 +13,7 @@ func setupConfig() (*Config, error) {
 		err error
 	)
 
-	c, err = OpenOndisk(nil, tempConfig)
+	c, err = OpenOndisk(tempConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is to fix issue #256. Removing parent from OpenOndisk from method signature which is not used.

**Risk:** Change in method signature will impact dependent programs so, there is need to plan how to incorporate this change.