### PR TITLE
Improve the static build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/static-build/

--- a/git_static.go
+++ b/git_static.go
@@ -3,9 +3,9 @@
 package git
 
 /*
-#cgo windows CFLAGS: -I${SRCDIR}/vendor/libgit2/include
-#cgo windows LDFLAGS: -L${SRCDIR}/vendor/libgit2/build/ -lgit2 -lwinhttp
-#cgo !windows pkg-config: --static ${SRCDIR}/vendor/libgit2/build/libgit2.pc
+#cgo windows CFLAGS: -I${SRCDIR}/static-build/install/include/
+#cgo windows LDFLAGS: -L${SRCDIR}/static-build/install/lib/ -lgit2 -lwinhttp
+#cgo !windows pkg-config: --static ${SRCDIR}/static-build/install/lib/pkgconfig/libgit2.pc
 #include <git2.h>
 
 #if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 27

--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -2,18 +2,19 @@
 
 set -ex
 
-VENDORED_PATH=vendor/libgit2
+ROOT="$(cd "$0/../.." && echo "${PWD}")"
+BUILD_PATH="${ROOT}/static-build"
+VENDORED_PATH="${ROOT}/vendor/libgit2"
 
-cd $VENDORED_PATH &&
-mkdir -p install/lib &&
-mkdir -p build &&
-cd build &&
+mkdir -p "${BUILD_PATH}/build" "${BUILD_PATH}/install/lib"
+
+cd "${BUILD_PATH}/build" &&
 cmake -DTHREADSAFE=ON \
       -DBUILD_CLAR=OFF \
       -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_C_FLAGS=-fPIC \
       -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-      -DCMAKE_INSTALL_PREFIX=../install \
-      .. &&
+      -DCMAKE_INSTALL_PREFIX="${BUILD_PATH}/install" \
+      "${VENDORED_PATH}" &&
 
 cmake --build . --target install


### PR DESCRIPTION
This change:

* Uses the installed version of both the library and the pkgconfig file,
  which fixes path resolution on Ubuntu Xenial.
* Uses quoting liberally so that paths with spaces in them are correctly
  handled.
* Moves the build+install directories to static-build/ in the git2go
  repository to avoid having a dirty vendor/libgit2 checkout.