### PR TITLE
Clean up one leaked temporary directory

### DIFF
--- a/reset_test.go
+++ b/reset_test.go
@@ -8,6 +8,8 @@ import (
 func TestResetToCommit(t *testing.T) {
 	t.Parallel()
 	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
 	seedTestRepo(t, repo)
 	// create commit to reset to
 	commitId, _ := updateReadme(t, repo, "testing reset")


### PR DESCRIPTION
A `defer cleanupTestRepo()` was missing.