### PR TITLE
Add support for Go 1.11 modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/libgit2/git2go


### PR DESCRIPTION
This change adds a `go.mod` file. An empty file is sufficient since this
project has no external dependencies. For people that want to use the static
version of libgit2, this module can be vendored and the following can be added
to their `go.mod` file:

    replace github.com/libgit2/git2go => ./vendor/github.com/libgit2/git2go