### PR TITLE
Make the static build script more portable

### DIFF
--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-ROOT="$(cd "$0/../.." && echo "${PWD}")"
+ROOT="$(cd -- "$(dirname -- "$0")" && git rev-parse --show-toplevel)"
 BUILD_PATH="${ROOT}/static-build"
 VENDORED_PATH="${ROOT}/vendor/libgit2"
 


### PR DESCRIPTION
This change stops using a relative cd (which as it turns out, _some_
shells don't like since `$0` is a file). Instead, this now uses
`dirname` and `git rev-parse --show-toplevel`, which should work
in more environments.