### PR TITLE
Fix receivers to Blob and Tree methods

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -24,18 +24,18 @@ func (b *Blob) AsObject() *Object {
 	return &b.Object
 }
 
-func (v *Blob) Size() int64 {
-	ret := int64(C.git_blob_rawsize(v.cast_ptr))
-	runtime.KeepAlive(v)
+func (b *Blob) Size() int64 {
+	ret := int64(C.git_blob_rawsize(b.cast_ptr))
+	runtime.KeepAlive(b)
 	return ret
 }
 
-func (v *Blob) Contents() []byte {
-	size := C.int(C.git_blob_rawsize(v.cast_ptr))
-	buffer := unsafe.Pointer(C.git_blob_rawcontent(v.cast_ptr))
+func (b *Blob) Contents() []byte {
+	size := C.int(C.git_blob_rawsize(b.cast_ptr))
+	buffer := unsafe.Pointer(C.git_blob_rawcontent(b.cast_ptr))
 
 	goBytes := C.GoBytes(buffer, size)
-	runtime.KeepAlive(v)
+	runtime.KeepAlive(b)
 
 	return goBytes
 }

--- a/tree.go
+++ b/tree.go
@@ -47,7 +47,7 @@ func newTreeEntry(entry *C.git_tree_entry) *TreeEntry {
 	}
 }
 
-func (t Tree) EntryByName(filename string) *TreeEntry {
+func (t *Tree) EntryByName(filename string) *TreeEntry {
 	cname := C.CString(filename)
 	defer C.free(unsafe.Pointer(cname))
 
@@ -67,7 +67,7 @@ func (t Tree) EntryByName(filename string) *TreeEntry {
 // free it, but you must not use it after the Tree is freed.
 //
 // Warning: this must examine every entry in the tree, so it is not fast.
-func (t Tree) EntryById(id *Oid) *TreeEntry {
+func (t *Tree) EntryById(id *Oid) *TreeEntry {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -84,7 +84,7 @@ func (t Tree) EntryById(id *Oid) *TreeEntry {
 
 // EntryByPath looks up an entry by its full path, recursing into
 // deeper trees if necessary (i.e. if there are slashes in the path)
-func (t Tree) EntryByPath(path string) (*TreeEntry, error) {
+func (t *Tree) EntryByPath(path string) (*TreeEntry, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	var entry *C.git_tree_entry
@@ -102,7 +102,7 @@ func (t Tree) EntryByPath(path string) (*TreeEntry, error) {
 	return newTreeEntry(entry), nil
 }
 
-func (t Tree) EntryByIndex(index uint64) *TreeEntry {
+func (t *Tree) EntryByIndex(index uint64) *TreeEntry {
 	entry := C.git_tree_entry_byindex(t.cast_ptr, C.size_t(index))
 	if entry == nil {
 		return nil
@@ -113,7 +113,7 @@ func (t Tree) EntryByIndex(index uint64) *TreeEntry {
 	return goEntry
 }
 
-func (t Tree) EntryCount() uint64 {
+func (t *Tree) EntryCount() uint64 {
 	num := C.git_tree_entrycount(t.cast_ptr)
 	runtime.KeepAlive(t)
 	return uint64(num)
@@ -133,7 +133,7 @@ func CallbackGitTreeWalk(_root *C.char, _entry unsafe.Pointer, ptr unsafe.Pointe
 	}
 }
 
-func (t Tree) Walk(callback TreeWalkCallback) error {
+func (t *Tree) Walk(callback TreeWalkCallback) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 


### PR DESCRIPTION
This change changes the signature of Blob and Tree methods so that they
have consistent receiver names and use pointers. This increases
consistency and avoids unnecessarily copying structs.