### PR TITLE
Free() the copies of repository.LookupXxx()

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -194,6 +194,7 @@ func (v *Repository) LookupTree(id *Oid) (*Tree, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer obj.Free()
 
 	return obj.AsTree()
 }
@@ -203,6 +204,7 @@ func (v *Repository) LookupCommit(id *Oid) (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer obj.Free()
 
 	return obj.AsCommit()
 }
@@ -212,6 +214,7 @@ func (v *Repository) LookupBlob(id *Oid) (*Blob, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer obj.Free()
 
 	return obj.AsBlob()
 }
@@ -221,6 +224,7 @@ func (v *Repository) LookupTag(id *Oid) (*Tag, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer obj.Free()
 
 	return obj.AsTag()
 }


### PR DESCRIPTION
`repository.LookupXxx()` allocate new go `Object`s that have a reference
to a `C.git_object`. Those are then duplicated with `git_object_dup()`,
so the original `Object`s linger unnecessarily until the Go GC kicks in.

This change explicitly calls `Free()` on the originals to avoid
unnecessary accumulation of garbage.
