### PR TITLE
Add odb.NewOdbBackendLoose()

### DIFF
--- a/odb_test.go
+++ b/odb_test.go
@@ -3,8 +3,11 @@ package git
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 )
 
@@ -185,4 +188,48 @@ func TestOdbWritepack(t *testing.T) {
 	if finalStats.IndexedObjects != 3 {
 		t.Errorf("mismatched indexed objects, expected 3, got %v", finalStats.IndexedObjects)
 	}
+}
+
+func TestOdbBackendLoose(t *testing.T) {
+	t.Parallel()
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	_, _ = seedTestRepo(t, repo)
+
+	odb, err := repo.Odb()
+	checkFatal(t, err)
+
+	looseObjectsDir, err := ioutil.TempDir("", fmt.Sprintf("loose_objects_%s", path.Base(repo.Path())))
+	checkFatal(t, err)
+	defer os.RemoveAll(looseObjectsDir)
+
+	looseObjectsBackend, err := NewOdbBackendLoose(looseObjectsDir, -1, false, 0, 0)
+	checkFatal(t, err)
+	if err := odb.AddBackend(looseObjectsBackend, 999); err != nil {
+		looseObjectsBackend.Free()
+		checkFatal(t, err)
+	}
+
+	str := "hello, world!"
+
+	writeStream, err := odb.NewWriteStream(int64(len(str)), ObjectBlob)
+	checkFatal(t, err)
+	n, err := io.WriteString(writeStream, str)
+	checkFatal(t, err)
+	if n != len(str) {
+		t.Fatalf("Bad write length %v != %v", n, len(str))
+	}
+
+	err = writeStream.Close()
+	checkFatal(t, err)
+
+	expectedId, err := NewOid("30f51a3fba5274d53522d0f19748456974647b4f")
+	checkFatal(t, err)
+	if !writeStream.Id.Equal(expectedId) {
+		t.Fatalf("writeStream.id = %v; want %v", writeStream.Id, expectedId)
+	}
+
+	_, err = os.Stat(path.Join(looseObjectsDir, expectedId.String()[:2], expectedId.String()[2:]))
+	checkFatal(t, err)
 }


### PR DESCRIPTION
This change adds support for odb.NewOdbBackendLoose(). This, together
with the git.Packbuilder, can do what Mempack does with a lot less
memory.