### PR TITLE
Fix the static linking build script

### DIFF
--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-ROOT="$(cd "$0/../.." && echo "${PWD}")"
+ROOT="$(cd "$(dirname $0)/.." && echo "${PWD}")"
 BUILD_PATH="${ROOT}/static-build"
 VENDORED_PATH="${ROOT}/vendor/libgit2"
 


### PR DESCRIPTION
When I run `make install-static` on my mac, it fails with an error message below:
```
$ make install-static
./script/build-libgit2-static.sh
++ cd ./script/build-libgit2-static.sh/../..
./script/build-libgit2-static.sh: line 5: cd: ./script/build-libgit2-static.sh/../..: Not a directory
+ ROOT=
make: *** [build-libgit2] Error 1
```
This PR fixes the problem by replacing "$0/../.." with "$(dirname $0)/..".

Thanks.