### PR TITLE
v27 Static build: Call CMake install

### DIFF
--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -16,4 +16,4 @@ cmake -DTHREADSAFE=ON \
       -DCMAKE_INSTALL_PREFIX=../install \
       .. &&
 
-cmake --build .
+cmake --build . --target install


### PR DESCRIPTION
After a `make install-static` call, `vendor/libgit2/install` is still empty because CMake's install wasn't called. Incorrectly setting `PKG_CONFIG_PATH` to point to `vendor/libgit2/build`'s `.pc` file will also fail because that one points back to the `install` folder which is empty.

Relates to this commit on master: https://github.com/libgit2/git2go/commit/b3256d9058aa93176190cb69f73afb72f0730100