### PR TITLE
script/build-libgit2-static.sh: correctly set ROOT

### DIFF
--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-ROOT="$(cd "$0/../.." && echo "${PWD}")"
+ROOT="$(cd "$(dirname "$0")/.." && echo "${PWD}")"
 BUILD_PATH="${ROOT}/static-build"
 VENDORED_PATH="${ROOT}/vendor/libgit2"
 


### PR DESCRIPTION
The ROOT variable is not being set correctly. Need to use dirname against
$0 as well as only go up one directory instead of two.