### PR TITLE
config.go: DefaultConfig() for loading default system config

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,6 +55,19 @@ type Config struct {
 	ptr *C.git_config
 }
 
+func DefaultConfig() (*Config, error) {
+	config := new(Config)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if ret := C.git_config_open_default(&config.ptr); ret < 0 {
+		return nil, MakeGitError(ret)
+	}
+
+	return config, nil
+}
+
 // NewConfig creates a new empty configuration object
 func NewConfig() (*Config, error) {
 	config := new(Config)


### PR DESCRIPTION
This adds a function wrapping `git_config_open_default`.