### PR TITLE
Add git_commit_message_encoding support

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -28,6 +28,12 @@ func (c *Commit) Message() string {
 	return ret
 }
 
+func (c *Commit) MessageEncoding() string {
+	ret := C.GoString(C.git_commit_message_encoding(c.cast_ptr))
+	runtime.KeepAlive(c)
+	return ret
+}
+
 func (c *Commit) RawMessage() string {
 	ret := C.GoString(C.git_commit_message_raw(c.cast_ptr))
 	runtime.KeepAlive(c)


### PR DESCRIPTION
This adds MessageEncoding() method to Commit struct, which simply returns the result of git_commit_message_encoding function.

I want to add git_commit_message_encoding function support because I encountered a problem where commit messages must be assured of being UTF-8 to pass them through gRPC.
For the purpose, I need to know the encoding of commit messages.

Thanks.