### PR TITLE
Build on Windows using MSYS2

### DIFF
--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -5,15 +5,26 @@ set -ex
 VENDORED_PATH=vendor/libgit2
 
 cd $VENDORED_PATH &&
-mkdir -p install/lib &&
 mkdir -p build &&
-cd build &&
-cmake -DTHREADSAFE=ON \
+cd build
+
+if [ "$OSTYPE" = "msys" ]; then
+    cmake -DTHREADSAFE=ON \
       -DBUILD_CLAR=OFF \
       -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_C_FLAGS=-fPIC \
       -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-      -DCMAKE_INSTALL_PREFIX=../install \
-      .. &&
+      -DCMAKE_INSTALL_PREFIX=install \
+      -G "MSYS Makefiles" \
+      ..
+else
+    cmake -DTHREADSAFE=ON \
+      -DBUILD_CLAR=OFF \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DCMAKE_C_FLAGS=-fPIC \
+      -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+      -DCMAKE_INSTALL_PREFIX=install \
+      ..
+fi
 
-cmake --build .
+cmake --build . --target install


### PR DESCRIPTION
Similar to Unix, this allows running 'make install' from a MinGW shell
on Windows, installed using MSYS2.

Prerequisites:

- Install MSYS2 from http://msys2.github.io and follow the instructions
  on that page
- Install MinGW as explained here http://stackoverflow.com/a/30071634/1104534
- In addition to 'mingw-w64-x86_64-gcc', you'll also need the following:
  $ pacman -S make mingw-w64-x86_64-cmake mingw-w64-x86_64-pkg-config

Build libgit2 and git2go:

- Open the "MinGW-w64 Win64 Shell" (or 32-bit) and run 'make install'
from the root of git2go. 'git2go.a' should install in
'GOPATH\pkg\windows_amd64\github.com\libgit2'.

When building your app, you'll need gcc available in your PATH,
so you might want to add 'C:\msys64\mingw64\bin' to the PATH.