### PR TITLE
fix invalid guard forcing v27 instead of v28

### DIFF
--- a/git_dynamic.go
+++ b/git_dynamic.go
@@ -6,8 +6,8 @@ package git
 #include <git2.h>
 #cgo pkg-config: libgit2
 
-#if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 27
-# error "Invalid libgit2 version; this git2go supports libgit2 v0.27"
+#if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 28
+# error "Invalid libgit2 version; this git2go supports libgit2 v0.28"
 #endif
 
 */


### PR DESCRIPTION
A few months ago a PR has been made to [support v28](https://github.com/libgit2/git2go/commit/5fda6dd90191b1c51a1785ad7cabd2fd5b05e802), but the guard around the dynamic lib hasn't been updated. This PR fixes that.