### PR TITLE
script: use git rev-parse to get top level dir

### DIFF
--- a/script/build-libgit2-static.sh
+++ b/script/build-libgit2-static.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-ROOT="$(cd "$0/../.." && echo "${PWD}")"
+ROOT="$(git rev-parse --show-toplevel)"
 BUILD_PATH="${ROOT}/static-build"
 VENDORED_PATH="${ROOT}/vendor/libgit2"
 


### PR DESCRIPTION
The existing approach doesn't work on recent
stock macOS shell.

Fixes #504