### PR TITLE
provide param names in DiffForEachFileCallback

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -284,7 +284,7 @@ type diffForEachData struct {
 	Error        error
 }
 
-type DiffForEachFileCallback func(DiffDelta, float64) (DiffForEachHunkCallback, error)
+type DiffForEachFileCallback func(delta DiffDelta, progress float64) (DiffForEachHunkCallback, error)
 
 type DiffDetail int
 


### PR DESCRIPTION
Without a parameter name, the float64 param is pretty inscrutable.