### PR TITLE
Fix libgit2 version dependency for dynamic linking

### DIFF
--- a/git_dynamic.go
+++ b/git_dynamic.go
@@ -6,8 +6,8 @@ package git
 #include <git2.h>
 #cgo pkg-config: libgit2
 
-#if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 27
-# error "Invalid libgit2 version; this git2go supports libgit2 v0.27"
+#if LIBGIT2_VER_MAJOR != 0 || LIBGIT2_VER_MINOR != 28
+# error "Invalid libgit2 version; this git2go supports libgit2 v0.28"
 #endif
 
 */


### PR DESCRIPTION
```
$ go get github.com/libgit2/git2go@v0.28.4
go: finding github.com/libgit2 v0.28.4
go: finding github.com v0.28.4
# github.com/libgit2/git2go
../../../../pkg/mod/github.com/libgit2/git2go@v0.28.4/git_dynamic.go:10:3: error: "Invalid libgit2 version; this git2go supports libgit2 v0.27"
# error "Invalid libgit2 version; this git2go supports libgit2 v0.27"
  ^
1 error generated.
```

Linking with libgit2 version:0.28.4 dynamic link library fails since git2go is incorrectly looking for v0.27 of libgit2. Static linking has the required version updates.

This would require tagging git2go with a minor version bump