### PR TITLE
Add the /v28 suffix to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/libgit2/git2go
+module github.com/libgit2/git2go/v28


### PR DESCRIPTION
This is compliant with
https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher,
which says

```
Major branch: Update the go.mod file to include a /v3 at the end of the
module path in the module directive (e.g., module
github.com/my/module/v3). Update import statements within the module to
also use /v3 (e.g., import "github.com/my/module/v3/mypkg"). Tag the
release with v3.0.0.
```

This also means that unfortunately we cannot keep using libgit2's exact
version number (plus a build number for git2go purposes, since go only
recognizes vMAJOR.MINOR.PATCH format).

(Tentatively) fixes: #536