### PR TITLE
Fix the DiffFlag type

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -14,7 +14,7 @@ import (
 	"unsafe"
 )
 
-type DiffFlag int
+type DiffFlag uint32
 
 const (
 	DiffFlagBinary    DiffFlag = C.GIT_DIFF_FLAG_BINARY


### PR DESCRIPTION
This change makes the underlying type of DiffFlag be uint32 instead of
int. That makes it possible to build on 32-bit systems.

Fixes: #487