### PR TITLE
Resolves issue #541 - typo in error code 'ErrAmbigious'

### DIFF
--- a/git.go
+++ b/git.go
@@ -61,6 +61,8 @@ const (
 	// Object exists preventing operation
 	ErrExists ErrorCode = C.GIT_EEXISTS
 	// More than one object matches
+	ErrAmbiguous ErrorCode = C.GIT_EAMBIGUOUS
+	// (backwards compatibility misspelling)
 	ErrAmbigious ErrorCode = C.GIT_EAMBIGUOUS
 	// Output buffer too short to hold data
 	ErrBuffs ErrorCode = C.GIT_EBUFS


### PR DESCRIPTION
I've added an additional constant with the correct spelling. I did this
rather than removing the existing constant to avoid breaking existing
code with the misspelled name.