### PR TITLE
Update the Travis setup for release-0.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,13 @@ language: go
 
 install:
   - cd "${HOME}"
-  - wget -O libgit2-0.22.1.tar.gz https://github.com/libgit2/libgit2/archive/v0.22.1.tar.gz
-  - tar -xzvf libgit2-0.22.1.tar.gz
-  - cd libgit2-0.22.1 && mkdir build && cd build
+  - wget -O libgit2-0.22.3.tar.gz https://github.com/libgit2/libgit2/archive/v0.22.3.tar.gz
+  - tar -xzvf libgit2-0.22.3.tar.gz
+  - cd libgit2-0.22.3 && mkdir build && cd build
   - cmake -DTHREADSAFE=ON -DBUILD_CLAR=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX=/usr/local .. && make && sudo make install
   - sudo ldconfig
   - cd "${TRAVIS_BUILD_DIR}"
 
 go:
-  - 1.1
-  - 1.2
   - 1.3
   - 1.4
-  - tip
-
-matrix:
-  allow_failures:
-    - go: tip


### PR DESCRIPTION
This change:

* Stops running tests under Go 1.1 and Go 1.2, since Travis no longer
  supports them.
* Stops running tests under Go tip, since Go 1.6 changed the rules for
  pointers changed and the code no longer works for that version (or
  beyond).
* Uprevs libgit (test) to v0.22.3.