### PR TITLE
Update the Travis setup for release-0.23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ sudo: required
 install: ./script/install-libgit2.sh
 
 go:
-  - 1.1
-  - 1.2
   - 1.3
   - 1.4
   - 1.5
+  - "1.13"
+  - "1.14"
   - tip
 
 matrix:

--- a/config_test.go
+++ b/config_test.go
@@ -62,7 +62,7 @@ var tests = []TestRunner{
 			t.Errorf("Got LookupBool error: '%v', expected none\n", err)
 		}
 		if !val {
-			t.Errorf("Got %b from LookupBool, expected 'false'\n", val)
+			t.Errorf("Got %v from LookupBool, expected 'false'\n", val)
 		}
 	},
 	// LookupInt32

--- a/script/install-libgit2.sh
+++ b/script/install-libgit2.sh
@@ -13,9 +13,9 @@ if [ "x$TRAVIS_BRANCH" = "xnext" ]; then
 fi
 
 cd "${HOME}"
-wget -O libgit2-0.23.1.tar.gz https://github.com/libgit2/libgit2/archive/v0.23.1.tar.gz
-tar -xzvf libgit2-0.23.1.tar.gz
-cd libgit2-0.23.1 && mkdir build && cd build
+wget -O libgit2-0.23.4.tar.gz https://github.com/libgit2/libgit2/archive/v0.23.4.tar.gz
+tar -xzvf libgit2-0.23.4.tar.gz
+cd libgit2-0.23.4 && mkdir build && cd build
 cmake -DTHREADSAFE=ON -DBUILD_CLAR=OFF -DCMAKE_BUILD_TYPE="RelWithDebInfo" .. && make && sudo make install
 sudo ldconfig
 cd "${TRAVIS_BUILD_DIR}"


### PR DESCRIPTION
This change:

* Stops running tests under Go 1.1 and Go 1.2, since Travis no longer
  supports them.
* Uprevs libgit (test) to v0.23.4.