### PR TITLE
Update the Travis setup for release-0.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,8 @@ sudo: required
 install: ./script/install-libgit2.sh
 
 go:
-  - 1.1
-  - 1.2
   - 1.3
   - 1.4
   - 1.5
   - 1.6
   - 1.7
-  - tip
-
-matrix:
-  allow_failures:
-    - go: tip

--- a/config_test.go
+++ b/config_test.go
@@ -62,7 +62,7 @@ var tests = []TestRunner{
 			t.Errorf("Got LookupBool error: '%v', expected none\n", err)
 		}
 		if !val {
-			t.Errorf("Got %b from LookupBool, expected 'false'\n", val)
+			t.Errorf("Got %v from LookupBool, expected 'false'\n", val)
 		}
 	},
 	// LookupInt32

--- a/script/install-libgit2.sh
+++ b/script/install-libgit2.sh
@@ -13,7 +13,7 @@ if [ "x$TRAVIS_BRANCH" = "xnext" ]; then
 fi
 
 cd "${HOME}"
-LG2VER="0.24.0"
+LG2VER="0.24.6"
 wget -O libgit2-${LG2VER}.tar.gz https://github.com/libgit2/libgit2/archive/v${LG2VER}.tar.gz
 tar -xzvf libgit2-${LG2VER}.tar.gz
 cd libgit2-${LG2VER} && mkdir build && cd build


### PR DESCRIPTION
This change:

* Stops running tests under Go 1.1 and Go 1.2, since Travis no longer
  supports them.
* Stops running tests under Go tip. Go 1.8+ requires runtime.KeepAlive()
  to keep some of the references alive across CGo invocations, but that
  was introduced in Go 1.7, and that would break older Go versions.
* Fixes a formatting bug that was breaking under newer Go releases.
* Uprevs libgit (test) to v0.24.6.