### PR TITLE
Add the version number to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/libgit2/git2go
+module github.com/libgit2/git2go/v29
 
 go 1.13


### PR DESCRIPTION
This is the second take on trying to tag the current release with a Go
version.