### PR TITLE
Add a debug allocator

### DIFF
--- a/debug_allocator.c
+++ b/debug_allocator.c
@@ -1,0 +1,193 @@
+#include "_cgo_export.h"
+
+#include <assert.h>
+#include <execinfo.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+
+#include <git2.h>
+#include <git2/common.h>
+#include <git2/sys/alloc.h>
+
+static git_allocator _go_git_system_allocator;
+static git_allocator _go_git_debug_allocator;
+
+static int __alloc_fd = -1;
+typedef struct __attribute__ ((__packed__)) {
+	uint32_t type;
+	int32_t line;
+	uint64_t ptr;
+	uint64_t len;
+	uint64_t filelen;
+	uint64_t btlen;
+} __alloc_message;
+static_assert(sizeof(__alloc_message) == 40, "Unexpected size of __alloc_message");
+
+static void log_alloc_event(char type, const void* ptr, size_t len, const char *file, int line) {
+	void *btaddr[16];
+	__alloc_message msg = {
+		.type = type,
+		.line = line,
+		.ptr = (uint64_t)ptr,
+		.len = len,
+		.filelen = (file ? strlen(file) : 0),
+		.btlen = 0,
+	};
+	struct iovec iov[18] = {
+		{.iov_base = &msg, .iov_len = sizeof(msg)},
+		{.iov_base = (char *)file, .iov_len = msg.filelen},
+	};
+	ssize_t expected = iov[0].iov_len + iov[1].iov_len;
+	char **strings = NULL;
+	int iov_count = 2;
+
+	if (type == 'A' || type == 'R') {
+		size_t i;
+		msg.btlen = backtrace(btaddr, 16);
+		strings = backtrace_symbols(btaddr, (int)msg.btlen);
+
+		for (i = 0; i < msg.btlen; ++i) {
+			iov[iov_count].iov_base = strings[i];
+			iov[iov_count].iov_len = strlen(strings[i]) + 1;
+			expected += iov[iov_count].iov_len;
+			++iov_count;
+		}
+	}
+	if (writev(__alloc_fd, iov, iov_count) != expected) {
+		perror("writev");
+		abort();
+	}
+	free(strings);
+}
+
+static void *_go_git_debug_allocator__malloc(size_t len, const char *file, int line)
+{
+	void *ptr = _go_git_system_allocator.gmalloc(len, file, line);
+	if (ptr)
+		log_alloc_event('A', ptr, len, file, line);
+	return ptr;
+}
+
+static void *_go_git_debug_allocator__calloc(size_t nelem, size_t elsize, const char *file, int line)
+{
+	void *ptr = _go_git_system_allocator.gcalloc(nelem, elsize, file, line);
+	if (ptr)
+		log_alloc_event('A', ptr, nelem * elsize, file, line);
+	return ptr;
+}
+
+static char *_go_git_debug_allocator__strdup(const char *str, const char *file, int line)
+{
+	char *ptr = _go_git_system_allocator.gstrdup(str, file, line);
+	if (ptr)
+		log_alloc_event('A', ptr, strlen(ptr) + 1, file, line);
+	return ptr;
+}
+
+static char *_go_git_debug_allocator__strndup(const char *str, size_t n, const char *file, int line)
+{
+	char *ptr = _go_git_system_allocator.gstrndup(str, n, file, line);
+	if (ptr)
+		log_alloc_event('A', ptr, strlen(ptr) + 1, file, line);
+	return ptr;
+}
+
+static char *_go_git_debug_allocator__substrdup(const char *start, size_t n, const char *file, int line)
+{
+	char *ptr = _go_git_system_allocator.gsubstrdup(start, n, file, line);
+	if (ptr)
+		log_alloc_event('A', ptr, strlen(ptr) + 1, file, line);
+	return ptr;
+}
+
+static void *_go_git_debug_allocator__realloc(void *ptr, size_t size, const char *file, int line)
+{
+	void *new_ptr = _go_git_system_allocator.grealloc(ptr, size, file, line);
+	if (new_ptr != ptr) {
+		if (ptr)
+			log_alloc_event('D', ptr, 0, NULL, 0);
+		if (new_ptr)
+			log_alloc_event('A', new_ptr, size, file, line);
+	} else if (new_ptr) {
+		log_alloc_event('R', new_ptr, size, file, line);
+	}
+	return new_ptr;
+}
+
+static void *_go_git_debug_allocator__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
+{
+	void *new_ptr = _go_git_system_allocator.greallocarray(ptr, nelem, elsize, file, line);
+	if (new_ptr != ptr) {
+		if (ptr)
+			log_alloc_event('D', ptr, 0, NULL, 0);
+		if (new_ptr)
+			log_alloc_event('A', new_ptr, nelem * elsize, file, line);
+	} else if (new_ptr) {
+		log_alloc_event('R', new_ptr, nelem * elsize, file, line);
+	}
+	return new_ptr;
+}
+
+static void *_go_git_debug_allocator__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
+{
+	void *ptr = _go_git_system_allocator.gmallocarray(nelem, elsize, file, line);
+	if (ptr)
+		log_alloc_event('A', ptr, nelem * elsize, file, line);
+	return ptr;
+}
+
+static void _go_git_debug_allocator__free(void *ptr)
+{
+	_go_git_system_allocator.gfree(ptr);
+	if (ptr)
+		log_alloc_event('D', ptr, 0, NULL, 0);
+}
+
+int _go_git_setup_debug_allocator()
+{
+#if defined(LIBGIT2_STATIC)
+	struct sockaddr_un name = {};
+	int error;
+
+	__alloc_fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+	if (__alloc_fd == -1) {
+		perror("socket");
+		return -1;
+	}
+
+	name.sun_family = AF_UNIX;
+	strncpy(name.sun_path, "/run/git2go_alloc.sock", sizeof(name.sun_path) - 1);
+
+	if (connect(__alloc_fd, (const struct sockaddr *)&name, sizeof(name)) == -1) {
+		perror("connect");
+		return -1;
+	}
+
+	error = git_stdalloc_init_allocator(&_go_git_system_allocator);
+	if (error < 0)
+		return error;
+	_go_git_debug_allocator.gmalloc = _go_git_debug_allocator__malloc;
+	_go_git_debug_allocator.gcalloc = _go_git_debug_allocator__calloc;
+	_go_git_debug_allocator.gstrdup = _go_git_debug_allocator__strdup;
+	_go_git_debug_allocator.gstrndup = _go_git_debug_allocator__strndup;
+	_go_git_debug_allocator.gsubstrdup = _go_git_debug_allocator__substrdup;
+	_go_git_debug_allocator.grealloc = _go_git_debug_allocator__realloc;
+	_go_git_debug_allocator.greallocarray = _go_git_debug_allocator__reallocarray;
+	_go_git_debug_allocator.gmallocarray = _go_git_debug_allocator__mallocarray;
+	_go_git_debug_allocator.gfree = _go_git_debug_allocator__free;
+	error = git_libgit2_opts(GIT_OPT_SET_ALLOCATOR, &_go_git_debug_allocator);
+	if (error < 0)
+		return error;
+
+	return 0;
+#elif defined(LIBGIT2_DYNAMIC)
+	fprintf(stderr, "debug allocator is only enabled in static builds\n");
+	return -1;
+#else
+#error no LIBGIT2_STATIC or LIBGIT2_DYNAMIC defined!
+#endif
+}

--- a/git.go
+++ b/git.go
@@ -3,12 +3,14 @@ package git
 /*
 #include <git2.h>
 #include <git2/sys/openssl.h>
+extern int _go_git_setup_debug_allocator();
 */
 import "C"
 import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"os"
 	"runtime"
 	"strings"
 	"unsafe"
@@ -119,6 +121,12 @@ var pointerHandles *HandleList
 
 func init() {
 	pointerHandles = NewHandleList()
+
+	if val, ok := os.LookupEnv("GIT2GO_DEBUG_ALLOCATOR"); ok && val != "" {
+		if _, err := C._go_git_setup_debug_allocator(); err != nil {
+			panic(err)
+		}
+	}
 
 	C.git_libgit2_init()
 

--- a/git_dynamic.go
+++ b/git_dynamic.go
@@ -3,8 +3,9 @@
 package git
 
 /*
-#include <git2.h>
 #cgo pkg-config: libgit2
+#cgo CFLAGS: -DLIBGIT2_DYNAMIC
+#include <git2.h>
 
 #if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
 # error "Invalid libgit2 version; this git2go supports libgit2 v1.0"

--- a/git_static.go
+++ b/git_static.go
@@ -6,11 +6,11 @@ package git
 #cgo windows CFLAGS: -I${SRCDIR}/static-build/install/include/
 #cgo windows LDFLAGS: -L${SRCDIR}/static-build/install/lib/ -lgit2 -lwinhttp
 #cgo !windows pkg-config: --static ${SRCDIR}/static-build/install/lib/pkgconfig/libgit2.pc
+#cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
 #if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
 # error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
 #endif
-
 */
 import "C"

--- a/script/leak_detector.py
+++ b/script/leak_detector.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python3
+"""Tool to assist in debugging git2go memory leaks.
+
+In order to use, run this program as root and start the git2go binary with the
+`GIT2GO_DEBUG_ALLOCATOR=1` environment variable set. For best results, make
+sure that the program exits and calls `git.Shutdown()` at the end to remove
+most noise.
+"""
+
+import argparse
+import dataclasses
+import os
+import socket
+import struct
+from typing import Dict, Iterable, Tuple, Sequence
+
+
+@dataclasses.dataclass
+class Allocation:
+    """A single object allocation."""
+
+    filename: str
+    line: int
+    size: int
+    ptr: int
+    backtrace: Sequence[str]
+
+
+def _receive_allocation_messages(
+        conn: socket.socket) -> Iterable[Tuple[str, Allocation]]:
+    while True:
+        msg = conn.recv(4096)
+        if not msg:
+            break
+        (message_type, line, ptr, size, file_length,
+         _) = struct.unpack('@IiLLLL', msg[:40])
+        filename = msg[40:40 + file_length].decode('utf-8')
+        message_type = chr(message_type)
+        if message_type in ('A', 'R'):
+            yield message_type, Allocation(
+                filename, line, size, ptr,
+                tuple(
+                    frame.decode('utf-8') for frame in
+                    msg[40 + file_length:].rstrip(b'\x00').split(b'\x00')))
+        else:
+            yield message_type, Allocation(filename, line, size, ptr, ())
+
+
+@dataclasses.dataclass
+class LeakSummaryEntry:
+    """An entry in the leak summary."""
+
+    allocation_count: int
+    allocation_size: int
+    filename: str
+    line: int
+    backtrace: Sequence[str]
+
+
+def _process_leaked_allocations(
+        live_allocations: Dict[int, Allocation]) -> None:
+    """Print a summary of leaked allocations."""
+
+    if not live_allocations:
+        print('No leaks!')
+        return
+
+    backtraces: Dict[Sequence[str], LeakSummaryEntry] = {}
+    for obj in live_allocations.values():
+        if obj.backtrace not in backtraces:
+            backtraces[obj.backtrace] = LeakSummaryEntry(
+                0, 0, obj.filename, obj.line, obj.backtrace)
+        backtraces[obj.backtrace].allocation_count += 1
+        backtraces[obj.backtrace].allocation_size += obj.size
+    print(f'{"Total size":>20} | {"Average size":>20} | '
+          f'{"Allocations":>11} | Filename')
+    print(f'{"":=<20}=+={"":=<20}=+={"":=<11}=+={"":=<64}')
+    for entry in sorted(backtraces.values(),
+                        key=lambda e: e.allocation_size,
+                        reverse=True):
+        print(f'{entry.allocation_size:20} | '
+              f'{entry.allocation_size//entry.allocation_count:20} | '
+              f'{entry.allocation_count:11} | '
+              f'{entry.filename}:{entry.line}')
+        for frame in entry.backtrace:
+            print(f'{"":20} | {"":20} | {"":11} | {frame}')
+        print(f'{"":-<20}-+-{"":-<20}-+-{"":-<11}-+-{"":-<64}')
+    print()
+
+
+def _handle_connection(conn: socket.socket) -> None:
+    """Handle a single connection."""
+
+    live_allocations: Dict[int, Allocation] = {}
+    with conn:
+        for message_type, allocation in _receive_allocation_messages(conn):
+            if message_type in ('A', 'R'):
+                live_allocations[allocation.ptr] = allocation
+            elif message_type == 'D':
+                del live_allocations[allocation.ptr]
+            else:
+                raise Exception(f'Unknown message type "{message_type}"')
+    _process_leaked_allocations(live_allocations)
+
+
+def main() -> None:
+    """Tool to assist in debugging git2go memory leaks."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('socket_path',
+                        metavar='SOCKET-PATH',
+                        default='/run/git2go_alloc.sock',
+                        nargs='?',
+                        type=str)
+    args = parser.parse_args()
+
+    try:
+        os.unlink(args.socket_path)
+    except FileNotFoundError:
+        pass
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET) as sock:
+        sock.bind(args.socket_path)
+        os.chmod(args.socket_path, 0o666)
+        sock.listen(1)
+        while True:
+            conn, _ = sock.accept()
+            _handle_connection(conn)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This change allows debugging all the allocations performed by libgit2.
To enable, run the `./script/leak_detector.py` script (as root), which
makes a UNIX seqpacket socket listen at `/run/git2go_alloc.sock`. Once
that is running, set the environment variable GIT2GO_DEBUG_ALLOCATOR=1
and run the git2go program. Once the program exits, a leak summary will
be printed.

In order to reduce the amount of noise due to the static allocations
performed by libgit2, it is recommended to call `git.Shutdown()` before
exiting the program.