### PR TITLE
Fix a potential use-after-free in DiffNotifyCallback

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -77,7 +77,7 @@ func (v *Repository) PatchFromBuffers(oldPath, newPath string, oldBuf, newBuf []
 	cNewPath := C.CString(newPath)
 	defer C.free(unsafe.Pointer(cNewPath))
 
-	copts, _ := diffOptionsToC(opts)
+	copts := diffOptionsToC(opts, v)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()


### PR DESCRIPTION
This change makes the DiffNotifyCallback always use an "unowned"
*git.Diff that does _not_ run the finalizer. Since the underlying
git_diff object is still owned by libgit2, we shouldn't be calling
Diff.Free() on it, even by accident, since that would cause a whole lot
of undefined behavior.

Now instead of storing a reference to a *git.Diff in the intermediate
state while the diff operation is being done, create a brand new
*git.Diff for every callback invocation, and only create a fully-owned
*git.Diff when the diff operation is done and the ownership is
transfered to Go.