### PR TITLE
Rename methods with Get prefix

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -144,7 +144,7 @@ func (diff *Diff) NumDeltas() (int, error) {
 	return ret, nil
 }
 
-func (diff *Diff) GetDelta(index int) (DiffDelta, error) {
+func (diff *Diff) Delta(index int) (DiffDelta, error) {
 	if diff.ptr == nil {
 		return DiffDelta{}, ErrInvalid
 	}
@@ -152,6 +152,11 @@ func (diff *Diff) GetDelta(index int) (DiffDelta, error) {
 	ret := diffDeltaFromC(ptr)
 	runtime.KeepAlive(diff)
 	return ret, nil
+}
+
+// deprecated: You should use `Diff.Delta()` instead.
+func (diff *Diff) GetDelta(index int) (DiffDelta, error) {
+	return diff.Delta(index)
 }
 
 func newDiffFromC(ptr *C.git_diff, repo *Repository) *Diff {

--- a/index.go
+++ b/index.go
@@ -528,7 +528,7 @@ type IndexConflict struct {
 	Their    *IndexEntry
 }
 
-func (v *Index) GetConflict(path string) (IndexConflict, error) {
+func (v *Index) Conflict(path string) (IndexConflict, error) {
 
 	var cancestor *C.git_index_entry
 	var cour *C.git_index_entry
@@ -551,6 +551,11 @@ func (v *Index) GetConflict(path string) (IndexConflict, error) {
 	}
 	runtime.KeepAlive(v)
 	return ret, nil
+}
+
+// deprecated: You should use `Index.Conflict()` instead.
+func (v *Index) GetConflict(path string) (IndexConflict, error) {
+	return v.Conflict(path)
 }
 
 func (v *Index) RemoveConflict(path string) error {

--- a/merge_test.go
+++ b/merge_test.go
@@ -109,7 +109,7 @@ func TestMergeTreesWithoutAncestor(t *testing.T) {
 	if !index.HasConflicts() {
 		t.Fatal("expected conflicts in the index")
 	}
-	_, err = index.GetConflict("README")
+	_, err = index.Conflict("README")
 	checkFatal(t, err)
 
 }

--- a/settings.go
+++ b/settings.go
@@ -93,8 +93,13 @@ func EnableCaching(enabled bool) error {
 	}
 }
 
-func GetCachedMemory() (current int, allowed int, err error) {
+func CachedMemory() (current int, allowed int, err error) {
 	return getSizetSizet(C.GIT_OPT_GET_CACHED_MEMORY)
+}
+
+// deprecated: You should use `CachedMemory()` instead.
+func GetCachedMemory() (current int, allowed int, err error) {
+	return CachedMemory()
 }
 
 func SetCacheMaxSize(maxSize int) error {

--- a/settings_test.go
+++ b/settings_test.go
@@ -57,8 +57,8 @@ func TestEnableCaching(t *testing.T) {
 	checkFatal(t, err)
 }
 
-func TestGetCachedMemory(t *testing.T) {
-	current, allowed, err := GetCachedMemory()
+func TestCachedMemory(t *testing.T) {
+	current, allowed, err := CachedMemory()
 	checkFatal(t, err)
 
 	if current < 0 {


### PR DESCRIPTION
It is not Go idiomatic to put Get into the getter's name ([see here](https://golang.org/doc/effective_go.html#Getters)).

Based on the discussion with @lhchavez on Slack. He suggested the renaming and adding backward compatibility.