### PR TITLE
Add support for parsing git trailers

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,0 +1,40 @@
+package git
+
+/*
+#include <git2.h>
+*/
+import "C"
+import (
+	"runtime"
+	"unsafe"
+)
+
+type Trailer struct {
+	key   string
+	value string
+}
+
+func MessageTrailers(message string) ([]Trailer, error) {
+
+	var trailersC C.git_message_trailer_array
+
+	messageC := C.CString(message)
+	defer C.free(unsafe.Pointer(messageC))
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	ecode := C.git_message_trailers(&trailersC, messageC)
+	if ecode < 0 {
+		return nil, MakeGitError(ecode)
+	}
+	defer C.git_message_trailer_array_free(&trailersC)
+	trailers := make([]Trailer, trailersC.count)
+	var trailer *C.git_message_trailer
+	for i, p := 0, uintptr(unsafe.Pointer(trailersC.trailers)); i < int(trailersC.count); p += unsafe.Sizeof(C.git_message_trailer{}) {
+		trailer = (*C.git_message_trailer)(unsafe.Pointer(p))
+		trailers[i] = Trailer{key: C.GoString(trailer.key), value: C.GoString(trailer.value)}
+		i++
+	}
+	return trailers, nil
+}

--- a/message.go
+++ b/message.go
@@ -34,10 +34,9 @@ func MessageTrailers(message string) ([]Trailer, error) {
 	defer C.git_message_trailer_array_free(&trailersC)
 	trailers := make([]Trailer, trailersC.count)
 	var trailer *C.git_message_trailer
-	for i, p := 0, uintptr(unsafe.Pointer(trailersC.trailers)); i < int(trailersC.count); p += unsafe.Sizeof(C.git_message_trailer{}) {
+	for i, p := 0, uintptr(unsafe.Pointer(trailersC.trailers)); i < int(trailersC.count); i, p = i+1, p+unsafe.Sizeof(C.git_message_trailer{}) {
 		trailer = (*C.git_message_trailer)(unsafe.Pointer(p))
 		trailers[i] = Trailer{Key: C.GoString(trailer.key), Value: C.GoString(trailer.value)}
-		i++
 	}
 	return trailers, nil
 }

--- a/message.go
+++ b/message.go
@@ -9,11 +9,15 @@ import (
 	"unsafe"
 )
 
+// Trailer represents a single git message trailer.
 type Trailer struct {
 	key   string
 	value string
 }
 
+// MessageTrailers parses trailers out of a message, returning a slice of
+// Trailer structs. Trailers are key/value pairs in the last paragraph of a
+// message, not including any patches or conflicts that may be present.
 func MessageTrailers(message string) ([]Trailer, error) {
 
 	var trailersC C.git_message_trailer_array

--- a/message.go
+++ b/message.go
@@ -11,8 +11,8 @@ import (
 
 // Trailer represents a single git message trailer.
 type Trailer struct {
-	key   string
-	value string
+	Key   string
+	Value string
 }
 
 // MessageTrailers parses trailers out of a message, returning a slice of
@@ -37,7 +37,7 @@ func MessageTrailers(message string) ([]Trailer, error) {
 	var trailer *C.git_message_trailer
 	for i, p := 0, uintptr(unsafe.Pointer(trailersC.trailers)); i < int(trailersC.count); p += unsafe.Sizeof(C.git_message_trailer{}) {
 		trailer = (*C.git_message_trailer)(unsafe.Pointer(p))
-		trailers[i] = Trailer{key: C.GoString(trailer.key), value: C.GoString(trailer.value)}
+		trailers[i] = Trailer{Key: C.GoString(trailer.key), Value: C.GoString(trailer.value)}
 		i++
 	}
 	return trailers, nil

--- a/message.go
+++ b/message.go
@@ -19,7 +19,6 @@ type Trailer struct {
 // Trailer structs. Trailers are key/value pairs in the last paragraph of a
 // message, not including any patches or conflicts that may be present.
 func MessageTrailers(message string) ([]Trailer, error) {
-
 	var trailersC C.git_message_trailer_array
 
 	messageC := C.CString(message)

--- a/message_test.go
+++ b/message_test.go
@@ -19,14 +19,14 @@ func TestTrailers(t *testing.T) {
 		{
 			"commit with one trailer\n\nCo-authored-by: Alice <alice@example.com>\n",
 			[]Trailer{
-				Trailer{key: "Co-authored-by", value: "Alice <alice@example.com>"},
+				Trailer{Key: "Co-authored-by", Value: "Alice <alice@example.com>"},
 			},
 		},
 		{
 			"commit with two trailers\n\nCo-authored-by: Alice <alice@example.com>\nSigned-off-by: Bob <bob@example.com>\n",
 			[]Trailer{
-				Trailer{key: "Co-authored-by", value: "Alice <alice@example.com>"},
-				Trailer{key: "Signed-off-by", value: "Bob <bob@example.com>"}},
+				Trailer{Key: "Co-authored-by", Value: "Alice <alice@example.com>"},
+				Trailer{Key: "Signed-off-by", Value: "Bob <bob@example.com>"}},
 		},
 	}
 	for _, test := range tests {

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,42 @@
+package git
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestTrailers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected []Trailer
+	}{
+		{
+			"commit with zero trailers\n",
+			[]Trailer{},
+		},
+		{
+			"commit with one trailer\n\nCo-authored-by: Alice <alice@example.com>\n",
+			[]Trailer{
+				Trailer{key: "Co-authored-by", value: "Alice <alice@example.com>"},
+			},
+		},
+		{
+			"commit with two trailers\n\nCo-authored-by: Alice <alice@example.com>\nSigned-off-by: Bob <bob@example.com>\n",
+			[]Trailer{
+				Trailer{key: "Co-authored-by", value: "Alice <alice@example.com>"},
+				Trailer{key: "Signed-off-by", value: "Bob <bob@example.com>"}},
+		},
+	}
+	for _, test := range tests {
+		fmt.Printf("%s", test.input)
+		actual, err := MessageTrailers(test.input)
+		if err != nil {
+			t.Errorf("Trailers returned an unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(test.expected, actual) {
+			t.Errorf("expecting %#v\ngot %#v", test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Adds a wrapper for git_message_trailers which returns a slice of trailer
structs.

First pull request for git2go & first use of cgo, criticism welcomed, thanks!