### PR TITLE
Remove a couple of now-unnecessary CMake defines

### DIFF
--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -41,8 +41,6 @@ cmake -DTHREADSAFE=ON \
       -DCMAKE_C_FLAGS=-fPIC \
       -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
       -DCMAKE_INSTALL_PREFIX="${BUILD_PATH}/install" \
-      -DINCLUDE_INSTALL_DIR="${BUILD_PATH}/install/include" \
-      -DLIB_INSTALL_DIR="${BUILD_PATH}/install/lib" \
       "${VENDORED_PATH}" &&
 
 exec cmake --build . --target install


### PR DESCRIPTION
This change removes the `LIB_INSTALL_DIR` and `INCLUDE_INSTALL_DIR` from
the `script/build-libgit2.sh` script, since they are now unneeded and
just print a warning if they are used.