### PR TITLE
Revamp the ways in which the library can be built

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ When linking dynamically against a released version of libgit2, install it via y
 import "github.com/libgit2/git2go/v30"
 ```
 
-### Master branch, or static linking
+### Versioned branch, static linking
 
-If using `master` or building a branch statically, we need to build libgit2 first. In order to build it, you need `cmake`, `pkg-config` and a C compiler. You will also need the development packages for OpenSSL (outside of Windows or macOS) and LibSSH2 installed if you want libgit2 to support HTTPS and SSH respectively. Note that even if libgit2 is included in the resulting binary, its dependencies will not be.
+Follow the instructions for [Versioned branch, dynamic linking](#versioned-branch-dynamic-linking), but pass the `-tags static,system_libgit2` flag to all `go` commands that build any binaries. For instance:
+
+    go build -tags static,system_libgit2 github.com/my/project/...
+    go test -tags static,system_libgit2 github.com/my/project/...
+    go install -tags static,system_libgit2 github.com/my/project/...
+
+### Master branch, or vendored static linking
+
+If using `master` or building a branch with the vendored libgit2 statically, we need to build libgit2 first. In order to build it, you need `cmake`, `pkg-config` and a C compiler. You will also need the development packages for OpenSSL (outside of Windows or macOS) and LibSSH2 installed if you want libgit2 to support HTTPS and SSH respectively. Note that even if libgit2 is included in the resulting binary, its dependencies will not be.
 
 Run `go get -d github.com/libgit2/git2go` to download the code and go to your `$GOPATH/src/github.com/libgit2/git2go` directory. From there, we need to build the C code and put it into the resulting go binary.
 
@@ -84,7 +92,7 @@ For the stable version, `go test` will work as usual. For the `master` branch, s
 
 Alternatively, you can build the library manually first and then run the tests
 
-    ./script/build-libgit2-static.sh
+    make install-static
     go test -v -tags static ./...
 
 License

--- a/git_bundled_static.go
+++ b/git_bundled_static.go
@@ -1,4 +1,4 @@
-// +build static
+// +build static,!system_libgit2
 
 package git
 
@@ -6,11 +6,11 @@ package git
 #cgo windows CFLAGS: -I${SRCDIR}/static-build/install/include/
 #cgo windows LDFLAGS: -L${SRCDIR}/static-build/install/lib/ -lgit2 -lwinhttp
 #cgo !windows pkg-config: --static ${SRCDIR}/static-build/install/lib/pkgconfig/libgit2.pc
+#cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
 #if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
 # error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
 #endif
-
 */
 import "C"

--- a/git_system_dynamic.go
+++ b/git_system_dynamic.go
@@ -1,0 +1,14 @@
+// +build !static
+
+package git
+
+/*
+#cgo pkg-config: libgit2
+#cgo CFLAGS: -DLIBGIT2_DYNAMIC
+#include <git2.h>
+
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
+# error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
+#endif
+*/
+import "C"

--- a/git_system_static.go
+++ b/git_system_static.go
@@ -1,14 +1,14 @@
-// +build !static
+// +build static,system_libgit2
 
 package git
 
 /*
+#cgo pkg-config: libgit2 --static
+#cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
-#cgo pkg-config: libgit2
 
 #if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
 # error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
 #endif
-
 */
 import "C"


### PR DESCRIPTION
This change allows to link the system version of libgit2 statically.
Since `-tags static` is already used for the bundled version of the
library and to avoid breaking old workflows, `-tags
static,system_libgit2` is now used to select that.

This means that the valid combinations are:

| Flag                          | Effect                                        |
|-------------------------------|-----------------------------------------------|
| _No flags_                    | Dynamically-linked against the system libgit2 |
| `-tags static,system_libgit2` | Statically-linked against the system libgit2  |
| `-tags static`                | Statically-linked against the bundled libgit2 |

Note that there is no way to express dynamically linking against the
bundled libgit2 because that makes very little sense, since the binaries
wouldn't be able to be distributed. If that's still desired, the
`PKG_CONFIG_PATH` environment variable can set before building the code.
[`Makefile`](https://github.com/libgit2/git2go/blob/master/Makefile) has
an example of how it is used in the CI.