### PR TITLE
FetchOptions: add ability to specify ProxyOptions

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -697,7 +697,6 @@ func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
 	options.custom_headers = C.git_strarray{}
 	options.custom_headers.count = C.size_t(len(opts.Headers))
 	options.custom_headers.strings = makeCStringsFromStrings(opts.Headers)
-	options.proxy_opts = C.git_proxy_options{}
 	populateProxyOptions(&options.proxy_opts, &opts.ProxyOptions)
 }
 

--- a/remote.go
+++ b/remote.go
@@ -117,6 +117,9 @@ type FetchOptions struct {
 
 	// Headers are extra headers for the fetch operation.
 	Headers []string
+
+	// Proxy options to use for this fetch operation
+	*ProxyOptions
 }
 
 type ProxyType uint
@@ -694,6 +697,8 @@ func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
 	options.custom_headers = C.git_strarray{}
 	options.custom_headers.count = C.size_t(len(opts.Headers))
 	options.custom_headers.strings = makeCStringsFromStrings(opts.Headers)
+	options.proxy_opts = C.git_proxy_options{}
+	populateProxyOptions(&options.proxy_opts, opts.ProxyOptions)
 }
 
 func populatePushOptions(options *C.git_push_options, opts *PushOptions) {

--- a/remote.go
+++ b/remote.go
@@ -119,7 +119,7 @@ type FetchOptions struct {
 	Headers []string
 
 	// Proxy options to use for this fetch operation
-	*ProxyOptions
+	ProxyOptions ProxyOptions
 }
 
 type ProxyType uint
@@ -698,7 +698,7 @@ func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
 	options.custom_headers.count = C.size_t(len(opts.Headers))
 	options.custom_headers.strings = makeCStringsFromStrings(opts.Headers)
 	options.proxy_opts = C.git_proxy_options{}
-	populateProxyOptions(&options.proxy_opts, opts.ProxyOptions)
+	populateProxyOptions(&options.proxy_opts, &opts.ProxyOptions)
 }
 
 func populatePushOptions(options *C.git_push_options, opts *PushOptions) {


### PR DESCRIPTION
Prior to this change you could not specifiy proxy options on the
FetchOptions struct, which made it impossible to specify a proxy for an
initial clone. This change adds the ProxyOptions to the FetchOptions
struct so you can go through a proxy when cloning.