### PR TITLE
Fix installation of libgit2 into wrong libdir

### DIFF
--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -41,6 +41,7 @@ cmake -DTHREADSAFE=ON \
       -DCMAKE_C_FLAGS=-fPIC \
       -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
       -DCMAKE_INSTALL_PREFIX="${BUILD_PATH}/install" \
+      -DCMAKE_INSTALL_LIBDIR="lib" \
       "${VENDORED_PATH}" &&
 
 exec cmake --build . --target install


### PR DESCRIPTION
Upstream libgit2 has migrated to use the GNUInstallDirs module to decide
where things will be installed to by default. While it improves
consistency with the host system, we're not really after that when
building the vendored libgit2 library, and in fact libgit2.{a,pc} may
now be installed into a different directory than before as it started to
depend on the host platform.

Fix this by explicitly specifying that we want the library and pkgconfig
file to be installed into a plain "lib/" directory.