### PR TITLE
Fix null pointer dereference in status.ByIndex

### DIFF
--- a/status.go
+++ b/status.go
@@ -87,6 +87,8 @@ func (statusList *StatusList) ByIndex(index int) (StatusEntry, error) {
 	}
 	ptr := C.git_status_byindex(statusList.ptr, C.size_t(index))
 	if ptr == nil {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
 		return StatusEntry{}, MakeGitError(C.int(ErrNotFound))
 	}
 	entry := statusEntryFromC(ptr)

--- a/status.go
+++ b/status.go
@@ -86,6 +86,9 @@ func (statusList *StatusList) ByIndex(index int) (StatusEntry, error) {
 		return StatusEntry{}, ErrInvalid
 	}
 	ptr := C.git_status_byindex(statusList.ptr, C.size_t(index))
+	if ptr == nil {
+		return StatusEntry{}, MakeGitError(C.int(ErrNotFound))
+	}
 	entry := statusEntryFromC(ptr)
 	runtime.KeepAlive(statusList)
 

--- a/status.go
+++ b/status.go
@@ -6,6 +6,7 @@ package git
 import "C"
 
 import (
+	"errors"
 	"runtime"
 	"unsafe"
 )
@@ -87,7 +88,7 @@ func (statusList *StatusList) ByIndex(index int) (StatusEntry, error) {
 	}
 	ptr := C.git_status_byindex(statusList.ptr, C.size_t(index))
 	if ptr == nil {
-		return StatusEntry{}, fmt.Errorf("Index out of Bounds")
+		return StatusEntry{}, errors.New("index out of Bounds")
 	}
 	entry := statusEntryFromC(ptr)
 	runtime.KeepAlive(statusList)

--- a/status.go
+++ b/status.go
@@ -87,9 +87,7 @@ func (statusList *StatusList) ByIndex(index int) (StatusEntry, error) {
 	}
 	ptr := C.git_status_byindex(statusList.ptr, C.size_t(index))
 	if ptr == nil {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-		return StatusEntry{}, MakeGitError(C.int(ErrNotFound))
+		return StatusEntry{}, fmt.Errorf("Index out of Bounds")
 	}
 	entry := statusEntryFromC(ptr)
 	runtime.KeepAlive(statusList)

--- a/status_test.go
+++ b/status_test.go
@@ -69,9 +69,10 @@ func TestStatusNothing(t *testing.T) {
 
 	seedTestRepo(t, repo)
 
-	opts := &StatusOptions{}
-	opts.Show = StatusShowIndexAndWorkdir
-	opts.Flags = StatusOptIncludeUntracked | StatusOptRenamesHeadToIndex | StatusOptSortCaseSensitively
+	opts := &StatusOptions{
+		Show:  StatusShowIndexAndWorkdir,
+		Flags: StatusOptIncludeUntracked | StatusOptRenamesHeadToIndex | StatusOptSortCaseSensitively,
+	}
 
 	statusList, err := repo.StatusList(opts)
 	checkFatal(t, err)

--- a/status_test.go
+++ b/status_test.go
@@ -61,3 +61,30 @@ func TestStatusList(t *testing.T) {
 		t.Fatal("Incorrect entry path: ", entry.IndexToWorkdir.NewFile.Path)
 	}
 }
+
+func TestStatusNothing(t *testing.T) {
+	t.Parallel()
+	repo := createTestRepo(t)
+	defer cleanupTestRepo(t, repo)
+
+	seedTestRepo(t, repo)
+
+	opts := &StatusOptions{}
+	opts.Show = StatusShowIndexAndWorkdir
+	opts.Flags = StatusOptIncludeUntracked | StatusOptRenamesHeadToIndex | StatusOptSortCaseSensitively
+
+	statusList, err := repo.StatusList(opts)
+	checkFatal(t, err)
+
+	entryCount, err := statusList.EntryCount()
+	checkFatal(t, err)
+
+	if entryCount != 0 {
+		t.Error("expected no statuses in empty repo")
+	}
+
+	_, err = statusList.ByIndex(0)
+	if err == nil {
+		t.Error("expected error getting status by index")
+	}
+}

--- a/status_test.go
+++ b/status_test.go
@@ -81,7 +81,7 @@ func TestStatusNothing(t *testing.T) {
 	checkFatal(t, err)
 
 	if entryCount != 0 {
-		t.Error("expected no statuses in empty repo")
+		t.Fatal("expected no statuses in empty repo")
 	}
 
 	_, err = statusList.ByIndex(0)


### PR DESCRIPTION
`git_status_byindex` can return a null pointer if there is no statuses.