### PR TITLE
Refresh the GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.11', '1.12', '1.13' ]
+        go: [ '1.11', '1.12', '1.13', '1.14' ]
     name: Go ${{ matrix.go }}
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Set up Go
@@ -71,13 +71,13 @@ jobs:
       fail-fast: false
     name: Go (dynamic)
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.13'
+        go-version: '1.14'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -87,3 +87,47 @@ jobs:
         make build-libgit2-dynamic
     - name: Test
       run: make test-dynamic
+
+  build-system-dynamic:
+    strategy:
+      fail-fast: false
+    name: Go (system-wide, dynamic)
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.14'
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+    - name: Build libgit2
+      run: |
+        git submodule update --init
+        sudo ./script/build-libgit2.sh --dynamic --system
+    - name: Test
+      run: make test
+
+  build-system-static:
+    strategy:
+      fail-fast: false
+    name: Go (system-wide, static)
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.14'
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+    - name: Build libgit2
+      run: |
+        git submodule update --init
+        sudo ./script/build-libgit2.sh --static --system
+    - name: Test
+      run: go test --count=1 --tags "static,system_libgit2" ./...

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `master` branch follows the tip of libgit2 itself (with some lag) and as suc
 
 ### Which branch to send Pull requests to
 
-If there's something version-specific that you'd want to contribute to, you can send them to the `release-${MAJOR}-${MINOR}` branches, which follow libgit2's releases.
+If there's something version-specific that you'd want to contribute to, you can send them to the `release-${MAJOR}.${MINOR}` branches, which follow libgit2's releases.
 
 Installing
 ----------


### PR DESCRIPTION
This change:

* Builds the library with Go 1.14, too.
* Builds the non-legacy tests with Ubuntu Focal (20.04).
* Adds testing for system-wide libraries, both static and dynamic
  versions.
* Fixes a typo in the README.