### PR TITLE
Add a ReInit function

### DIFF
--- a/git.go
+++ b/git.go
@@ -149,6 +149,17 @@ func Shutdown() {
 	C.git_libgit2_shutdown()
 }
 
+// ReInit reinitializes the global state, this is useful if the effective user
+// id has changed and you want to update the stored search paths for gitconfig
+// files. This function frees any references to objects, so it should be called
+// before any other functions are called.
+func ReInit() {
+	pointerHandles.Clear()
+	C.git_libgit2_shutdown()
+	pointerHandles = NewHandleList()
+	C.git_libgit2_init()
+}
+
 // Oid represents the id for a Git object.
 type Oid [20]byte
 

--- a/git.go
+++ b/git.go
@@ -118,6 +118,10 @@ var (
 var pointerHandles *HandleList
 
 func init() {
+	initLibGit2()
+}
+
+func initLibGit2() {
 	pointerHandles = NewHandleList()
 
 	C.git_libgit2_init()
@@ -154,10 +158,8 @@ func Shutdown() {
 // files. This function frees any references to objects, so it should be called
 // before any other functions are called.
 func ReInit() {
-	pointerHandles.Clear()
-	C.git_libgit2_shutdown()
-	pointerHandles = NewHandleList()
-	C.git_libgit2_init()
+	Shutdown()
+	initLibGit2()
 }
 
 // Oid represents the id for a Git object.


### PR DESCRIPTION
libgit2 stores the lookup paths for gitconfig files in its global state.
This means that after a program changes its effective uid libgit2 will
still look for gitconfig files in the home directory of the original
uid. Expose a way to call C.git_libgit2_init so a user can reinitialize
the libgit2 global state.