### PR TITLE
Enable set the VENDORED_PATH for libgit2

### DIFF
--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -15,7 +15,7 @@ if [ "$#" -eq "0" ]; then
 	usage
 fi
 
-ROOT="$(cd "$(dirname "$0")/.." && echo "${PWD}")"
+ROOT=${ROOT-"$(cd "$(dirname "$0")/.." && echo "${PWD}")"}
 VENDORED_PATH=${VENDORED_PATH-"${ROOT}/vendor/libgit2"}
 BUILD_SYSTEM=OFF
 

--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -16,7 +16,7 @@ if [ "$#" -eq "0" ]; then
 fi
 
 ROOT="$(cd "$(dirname "$0")/.." && echo "${PWD}")"
-VENDORED_PATH="${ROOT}/vendor/libgit2"
+VENDORED_PATH=${VENDORED_PATH-"${ROOT}/vendor/libgit2"}
 BUILD_SYSTEM=OFF
 
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
### What this change is doing?
This change aims to enable us to set the `VENDORED_PATH` as an environment variable and failback to the default value if the environment variable is not set. Thus, this change should not break current behavior.

### Why we need this?
This will enable using the script to build libgit2 form source code downloaded manually.

Example:
```sh
LIBGIT2_VER="1.0.1"
DOWNLOAD_URL="https://codeload.github.com/libgit2/libgit2/tar.gz/v${LIBGIT2_VER}""
LIBGIT2_PATH="${HOME}/libgit2-${LIBGIT2_VER}"
wget -O "${LIBGIT2_PATH}.tar.gz" "$DOWNLOAD_URL"
tar -xzvf "${LIBGIT2_PATH}.tar.gz"


VENDORED_PATH=$LIBGIT2_PATH sh ./script/build-libgit2.sh --static
```