### PR TITLE
Enable change the system install path

### DIFF
--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -47,7 +47,7 @@ if [ -z "${BUILD_SHARED_LIBS}" ]; then
 fi
 
 if [ "${BUILD_SYSTEM}" = "ON" ]; then
-	BUILD_INSTALL_PREFIX="/usr"
+	BUILD_INSTALL_PREFIX=${SYSTEM_INSTALL_PREFIX-"/usr"}
 else
 	BUILD_INSTALL_PREFIX="${BUILD_PATH}/install"
 	mkdir -p "${BUILD_PATH}/install/lib"


### PR DESCRIPTION
#### Problem:
The current `CMAKE_INSTALL_PREFIX` value for the `system` build mode is `/usr`. However, in`macOS` as an example, you cannot write to `/usr` without `sudo` permission.

#### Proposed solution:
Enable changing the value to `/usr/local` (or any other path). This change makes the script use the value of the environment variable `SYSTEM_INSTALL_PREFIX` to select the installation path.  If the variable is not set, it fallback to the path `/usr`.