### PR TITLE
Use un-deprecated options init functions from libgit2

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -23,7 +23,7 @@ func DefaultBlameOptions() (BlameOptions, error) {
 	defer runtime.UnlockOSThread()
 
 	opts := C.git_blame_options{}
-	ecode := C.git_blame_init_options(&opts, C.GIT_BLAME_OPTIONS_VERSION)
+	ecode := C.git_blame_options_init(&opts, C.GIT_BLAME_OPTIONS_VERSION)
 	if ecode < 0 {
 		return BlameOptions{}, MakeGitError(ecode)
 	}

--- a/checkout.go
+++ b/checkout.go
@@ -134,7 +134,7 @@ func populateCheckoutOpts(ptr *C.git_checkout_options, opts *CheckoutOpts) *C.gi
 		return nil
 	}
 
-	C.git_checkout_init_options(ptr, 1)
+	C.git_checkout_options_init(ptr, 1)
 	ptr.checkout_strategy = C.uint(opts.Strategy)
 	ptr.disable_filters = cbool(opts.DisableFilters)
 	ptr.dir_mode = C.uint(opts.DirMode.Perm())

--- a/cherrypick.go
+++ b/cherrypick.go
@@ -50,7 +50,7 @@ func DefaultCherrypickOptions() (CherrypickOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_cherrypick_init_options(&c, C.GIT_CHERRYPICK_OPTIONS_VERSION)
+	ecode := C.git_cherrypick_options_init(&c, C.GIT_CHERRYPICK_OPTIONS_VERSION)
 	if ecode < 0 {
 		return CherrypickOptions{}, MakeGitError(ecode)
 	}

--- a/clone.go
+++ b/clone.go
@@ -77,7 +77,7 @@ func remoteCreateCallback(cremote unsafe.Pointer, crepo unsafe.Pointer, cname, c
 }
 
 func populateCloneOptions(ptr *C.git_clone_options, opts *CloneOptions) {
-	C.git_clone_init_options(ptr, C.GIT_CLONE_OPTIONS_VERSION)
+	C.git_clone_options_init(ptr, C.GIT_CLONE_OPTIONS_VERSION)
 
 	if opts == nil {
 		return

--- a/describe.go
+++ b/describe.go
@@ -43,7 +43,7 @@ func DefaultDescribeOptions() (DescribeOptions, error) {
 	defer runtime.UnlockOSThread()
 
 	opts := C.git_describe_options{}
-	ecode := C.git_describe_init_options(&opts, C.GIT_DESCRIBE_OPTIONS_VERSION)
+	ecode := C.git_describe_options_init(&opts, C.GIT_DESCRIBE_OPTIONS_VERSION)
 	if ecode < 0 {
 		return DescribeOptions{}, MakeGitError(ecode)
 	}
@@ -77,7 +77,7 @@ func DefaultDescribeFormatOptions() (DescribeFormatOptions, error) {
 	defer runtime.UnlockOSThread()
 
 	opts := C.git_describe_format_options{}
-	ecode := C.git_describe_init_format_options(&opts, C.GIT_DESCRIBE_FORMAT_OPTIONS_VERSION)
+	ecode := C.git_describe_format_options_init(&opts, C.GIT_DESCRIBE_FORMAT_OPTIONS_VERSION)
 	if ecode < 0 {
 		return DescribeFormatOptions{}, MakeGitError(ecode)
 	}

--- a/diff.go
+++ b/diff.go
@@ -512,7 +512,7 @@ func DefaultDiffOptions() (DiffOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_diff_init_options(&opts, C.GIT_DIFF_OPTIONS_VERSION)
+	ecode := C.git_diff_options_init(&opts, C.GIT_DIFF_OPTIONS_VERSION)
 	if ecode < 0 {
 		return DiffOptions{}, MakeGitError(ecode)
 	}
@@ -567,7 +567,7 @@ func DefaultDiffFindOptions() (DiffFindOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_diff_find_init_options(&opts, C.GIT_DIFF_FIND_OPTIONS_VERSION)
+	ecode := C.git_diff_find_options_init(&opts, C.GIT_DIFF_FIND_OPTIONS_VERSION)
 	if ecode < 0 {
 		return DiffFindOptions{}, MakeGitError(ecode)
 	}

--- a/merge.go
+++ b/merge.go
@@ -165,7 +165,7 @@ func DefaultMergeOptions() (MergeOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_merge_init_options(&opts, C.GIT_MERGE_OPTIONS_VERSION)
+	ecode := C.git_merge_options_init(&opts, C.GIT_MERGE_OPTIONS_VERSION)
 	if ecode < 0 {
 		return MergeOptions{}, MakeGitError(ecode)
 	}
@@ -477,7 +477,7 @@ func MergeFile(ancestor MergeFileInput, ours MergeFileInput, theirs MergeFileInp
 	var copts *C.git_merge_file_options
 	if options != nil {
 		copts = &C.git_merge_file_options{}
-		ecode := C.git_merge_file_init_options(copts, C.GIT_MERGE_FILE_OPTIONS_VERSION)
+		ecode := C.git_merge_file_options_init(copts, C.GIT_MERGE_FILE_OPTIONS_VERSION)
 		if ecode < 0 {
 			return nil, MakeGitError(ecode)
 		}

--- a/rebase.go
+++ b/rebase.go
@@ -140,7 +140,7 @@ func DefaultRebaseOptions() (RebaseOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_rebase_init_options(&opts, C.GIT_REBASE_OPTIONS_VERSION)
+	ecode := C.git_rebase_options_init(&opts, C.GIT_REBASE_OPTIONS_VERSION)
 	if ecode < 0 {
 		return RebaseOptions{}, MakeGitError(ecode)
 	}

--- a/remote.go
+++ b/remote.go
@@ -361,7 +361,7 @@ func pushUpdateReferenceCallback(refname, status *C.char, data unsafe.Pointer) i
 }
 
 func populateProxyOptions(ptr *C.git_proxy_options, opts *ProxyOptions) {
-	C.git_proxy_init_options(ptr, C.GIT_PROXY_OPTIONS_VERSION)
+	C.git_proxy_options_init(ptr, C.GIT_PROXY_OPTIONS_VERSION)
 	if opts == nil {
 		return
 	}
@@ -685,7 +685,7 @@ func (o *Remote) RefspecCount() uint {
 }
 
 func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
-	C.git_fetch_init_options(options, C.GIT_FETCH_OPTIONS_VERSION)
+	C.git_fetch_options_init(options, C.GIT_FETCH_OPTIONS_VERSION)
 	if opts == nil {
 		return
 	}
@@ -701,7 +701,7 @@ func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
 }
 
 func populatePushOptions(options *C.git_push_options, opts *PushOptions) {
-	C.git_push_init_options(options, C.GIT_PUSH_OPTIONS_VERSION)
+	C.git_push_options_init(options, C.GIT_PUSH_OPTIONS_VERSION)
 	if opts == nil {
 		return
 	}

--- a/revert.go
+++ b/revert.go
@@ -43,7 +43,7 @@ func DefaultRevertOptions() (RevertOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_revert_init_options(&opts, C.GIT_REVERT_OPTIONS_VERSION)
+	ecode := C.git_revert_options_init(&opts, C.GIT_REVERT_OPTIONS_VERSION)
 	if ecode < 0 {
 		return RevertOptions{}, MakeGitError(ecode)
 	}

--- a/stash.go
+++ b/stash.go
@@ -151,7 +151,7 @@ func DefaultStashApplyOptions() (StashApplyOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_stash_apply_init_options(&optsC, C.GIT_STASH_APPLY_OPTIONS_VERSION)
+	ecode := C.git_stash_apply_options_init(&optsC, C.GIT_STASH_APPLY_OPTIONS_VERSION)
 	if ecode < 0 {
 		return StashApplyOptions{}, MakeGitError(ecode)
 	}

--- a/status.go
+++ b/status.go
@@ -159,7 +159,7 @@ func (v *Repository) StatusList(opts *StatusOptions) (*StatusList, error) {
 		}
 	} else {
 		copts = &C.git_status_options{}
-		ret := C.git_status_init_options(copts, C.GIT_STATUS_OPTIONS_VERSION)
+		ret := C.git_status_options_init(copts, C.GIT_STATUS_OPTIONS_VERSION)
 		if ret < 0 {
 			return nil, MakeGitError(ret)
 		}

--- a/submodule.go
+++ b/submodule.go
@@ -360,7 +360,7 @@ func (sub *Submodule) Update(init bool, opts *SubmoduleUpdateOptions) error {
 }
 
 func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *SubmoduleUpdateOptions) error {
-	C.git_submodule_update_init_options(ptr, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
+	C.git_submodule_update_options_init(ptr, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
 
 	if opts == nil {
 		return nil


### PR DESCRIPTION
This PR move form linking against the deprecated `init_options` functions to the renamed `options_init` functions.

For more context see libgit2/libgit2@0b5ba0d744e69da5dc8c08d167c83dd87ed83af2 and libgit2/libgit2@c6184f0c4b209e462bf3f42ab20df2d13d8ee918.