### PR TITLE
apply: Add bindings for git_apply_to_tree

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -991,6 +991,24 @@ func (v *Repository) ApplyDiff(diff *Diff, location ApplyLocation, opts *ApplyOp
 	return nil
 }
 
+// ApplyToTree applies a Diff to a Tree and returns the resulting image as an Index.
+func (v *Repository) ApplyToTree(diff *Diff, tree *Tree, opts *ApplyOptions) (*Index, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var indexPtr *C.git_index
+	cOpts := opts.toC()
+	ecode := C.git_apply_to_tree(&indexPtr, v.ptr, tree.cast_ptr, diff.ptr, cOpts)
+	runtime.KeepAlive(diff)
+	runtime.KeepAlive(tree)
+	runtime.KeepAlive(cOpts)
+	if ecode != 0 {
+		return nil, MakeGitError(ecode)
+	}
+
+	return newIndexFromC(indexPtr, v), nil
+}
+
 // DiffFromBuffer reads the contents of a git patch file into a Diff object.
 //
 // The diff object produced is similar to the one that would be produced if you

--- a/git.go
+++ b/git.go
@@ -45,6 +45,7 @@ const (
 	ErrClassRevert     ErrorClass = C.GITERR_REVERT
 	ErrClassCallback   ErrorClass = C.GITERR_CALLBACK
 	ErrClassRebase     ErrorClass = C.GITERR_REBASE
+	ErrClassPatch      ErrorClass = C.GITERR_PATCH
 )
 
 type ErrorCode int
@@ -109,6 +110,8 @@ const (
 	ErrPassthrough ErrorCode = C.GIT_PASSTHROUGH
 	// Signals end of iteration with iterator
 	ErrIterOver ErrorCode = C.GIT_ITEROVER
+	// Patch application failed
+	ErrApplyFail ErrorCode = C.GIT_EAPPLYFAIL
 )
 
 var (


### PR DESCRIPTION
Adds bindings to the git_apply_to_tree function that allows applying
a diff directly to a tree.

Should this get merged, when do you anticipate a new release that includes these changes?