### PR TITLE
CI refresh (#666)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.11', '1.12', '1.13', '1.14' ]
+        go: [ '1.11', '1.12', '1.13', '1.14', '1.15' ]
     name: Go ${{ matrix.go }}
 
     runs-on: ubuntu-20.04
@@ -77,7 +77,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.14'
+        go-version: '1.15'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -99,7 +99,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.14'
+        go-version: '1.15'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -121,7 +121,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.14'
+        go-version: '1.15'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: go
 
 go:
-  - "1.7"
-  - "1.8"
-  - "1.9"
-  - "1.10"
-  - "1.11"
-  - "1.12"
-  - "1.13"
   - tip
 
 install:
@@ -16,10 +9,6 @@ install:
 
 script:
   - make test-static
-
-matrix:
-  allow_failures:
-    - go: tip
 
 git:
   submodules: true


### PR DESCRIPTION
This change:

* Makes the Travis tests only run tip, since the rest of the Go versions are better served by GitHub Actions.
* Use Go 1.15 in the CI. This has been released for a while.

(cherry picked from commit f83530b18dc46867ed06fc261b309b8b545a3b6f)