### PR TITLE
Create v31 to support libgit2 v1.1.x

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,11 +7,12 @@ on:
 jobs:
 
   backport:
+    name: Backport change to branch ${{ matrix.branch }}
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'release-0.28', 'release-0.27' ]
-    name: Backport change to branch ${{ matrix.branch }}
+        branch: [ 'release-0.30', 'release-0.28', 'release-0.27' ]
 
     runs-on: ubuntu-20.04
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Due to the fact that Go 1.11 module versions have semantic meaning and don't nec
 | 0.28    | v28           |
 | 0.27    | v27           |
 
-You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.0 installed, you'd import git2go v31 with:
+You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.1 installed, you'd import git2go v31 with:
 
 ```sh
 go get github.com/libgit2/git2go/v31

--- a/README.md
+++ b/README.md
@@ -10,19 +10,20 @@ Due to the fact that Go 1.11 module versions have semantic meaning and don't nec
 
 | libgit2 | git2go        |
 |---------|---------------|
-| master  | (will be v31) |
+| master  | (will be v32) |
+| 1.1     | v31           |
 | 1.0     | v30           |
 | 0.99    | v29           |
 | 0.28    | v28           |
 | 0.27    | v27           |
 
-You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.0 installed, you'd import git2go v30 with
+You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.0 installed, you'd import git2go v31 with:
 
 ```sh
-go get github.com/libgit2/git2go/v30
+go get github.com/libgit2/git2go/v31
 ```
 ```go
-import "github.com/libgit2/git2go/v30"
+import "github.com/libgit2/git2go/v31"
 ```
 
 which will ensure there are no sudden changes to the API.
@@ -43,10 +44,10 @@ This project wraps the functionality provided by libgit2. If you're using a vers
 
 ### Versioned branch, dynamic linking
 
-When linking dynamically against a released version of libgit2, install it via your system's package manager. CGo will take care of finding its pkg-config file and set up the linking. Import via Go modules, e.g. to work against libgit2 v1.0
+When linking dynamically against a released version of libgit2, install it via your system's package manager. CGo will take care of finding its pkg-config file and set up the linking. Import via Go modules, e.g. to work against libgit2 v1.1
 
 ```go
-import "github.com/libgit2/git2go/v30"
+import "github.com/libgit2/git2go/v31"
 ```
 
 ### Versioned branch, static linking
@@ -76,7 +77,7 @@ In order to let Go pass the correct flags to `pkg-config`, `-tags static` needs 
 
 One thing to take into account is that since Go expects the `pkg-config` file to be within the same directory where `make install-static` was called, so the `go.mod` file may need to have a [`replace` directive](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive) so that the correct setup is achieved. So if `git2go` is checked out at `$GOPATH/src/github.com/libgit2/git2go` and your project at `$GOPATH/src/github.com/my/project`, the `go.mod` file of `github.com/my/project` might need to have a line like
 
-    replace github.com/libgit2/git2go/v30 ../../libgit2/git2go
+    replace github.com/libgit2/git2go/v31 ../../libgit2/git2go
 
 Parallelism and network operations
 ----------------------------------

--- a/git_bundled_static.go
+++ b/git_bundled_static.go
@@ -9,8 +9,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
-# error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 1
+# error "Invalid libgit2 version; this git2go supports libgit2 v1.1"
 #endif
 */
 import "C"

--- a/git_system_dynamic.go
+++ b/git_system_dynamic.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
-# error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 1
+# error "Invalid libgit2 version; this git2go supports libgit2 v1.1"
 #endif
 */
 import "C"

--- a/git_system_static.go
+++ b/git_system_static.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
-# error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 1
+# error "Invalid libgit2 version; this git2go supports libgit2 v1.1"
 #endif
 */
 import "C"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libgit2/git2go/v30
+module github.com/libgit2/git2go/v31
 
 go 1.13
 


### PR DESCRIPTION
The libgit2 `v1.1.0` is released two weeks ago. This PR allows `git2go` to link against the new version.