### PR TITLE
Implement an option to control hash verification

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -93,6 +93,14 @@ func EnableCaching(enabled bool) error {
 	}
 }
 
+func EnableStrictHashVerification(enabled bool) error {
+	if enabled {
+		return setSizet(C.GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 1)
+	} else {
+		return setSizet(C.GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 0)
+	}
+}
+
 func CachedMemory() (current int, allowed int, err error) {
 	return getSizetSizet(C.GIT_OPT_GET_CACHED_MEMORY)
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -57,6 +57,14 @@ func TestEnableCaching(t *testing.T) {
 	checkFatal(t, err)
 }
 
+func TestEnableStrictHashVerification(t *testing.T) {
+	err := EnableStrictHashVerification(false)
+	checkFatal(t, err)
+
+	err = EnableStrictHashVerification(true)
+	checkFatal(t, err)
+}
+
 func TestCachedMemory(t *testing.T) {
 	current, allowed, err := CachedMemory()
 	checkFatal(t, err)


### PR DESCRIPTION
Add a binding to enable/disable hash verification using the `GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION` option.

Change type: #minor