### PR TITLE
Use the correct branch name for backporting into v1.0

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'release-0.30', 'release-0.28', 'release-0.27' ]
+        branch: [ 'release-1.0', 'release-0.28', 'release-0.27' ]
 
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
This change uses the correct branch name (`release-1.0`) to backport
changes into the v1.0 branch.