### PR TITLE
Add GIT_BLAME_USE_MAILMAP flag

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -47,6 +47,7 @@ const (
 	BlameTrackCopiesSameCommitCopies BlameOptionsFlag = C.GIT_BLAME_TRACK_COPIES_SAME_COMMIT_COPIES
 	BlameTrackCopiesAnyCommitCopies  BlameOptionsFlag = C.GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES
 	BlameFirstParent                 BlameOptionsFlag = C.GIT_BLAME_FIRST_PARENT
+	BlameUseMailmap                  BlameOptionsFlag = C.GIT_BLAME_USE_MAILMAP
 )
 
 func (v *Repository) BlameFile(path string, opts *BlameOptions) (*Blame, error) {


### PR DESCRIPTION
The `GIT_BLAME_USE_MAILMAP` blame option flag was introduced in libgit2 v0.28.

Change type: #minor