### PR TITLE
Add GIT_BLAME_IGNORE_WHITESPACE flag

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -47,6 +47,7 @@ const (
 	BlameTrackCopiesSameCommitCopies BlameOptionsFlag = C.GIT_BLAME_TRACK_COPIES_SAME_COMMIT_COPIES
 	BlameTrackCopiesAnyCommitCopies  BlameOptionsFlag = C.GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES
 	BlameFirstParent                 BlameOptionsFlag = C.GIT_BLAME_FIRST_PARENT
+	BlameIgnoreWhitespace            BlameOptionsFlag = C.GIT_BLAME_IGNORE_WHITESPACE
 )
 
 func (v *Repository) BlameFile(path string, opts *BlameOptions) (*Blame, error) {


### PR DESCRIPTION
The `GIT_BLAME_IGNORE_WHITESPACE` blame option flag was introduced in libgit2 v1.1.0.

Change type: #minor