### PR TITLE
Add ReferenceNormalizeName

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -489,6 +489,11 @@ func ReferenceIsValidName(name string) bool {
 	return false
 }
 
+const (
+	// This should match GIT_REFNAME_MAX in src/refs.h
+	refnameMaxLength = 1024
+)
+
 type ReferenceFormat uint
 
 const (
@@ -509,7 +514,7 @@ func ReferenceNormalizeName(name string, flags ReferenceFormat) (string, error) 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	bufSize := C.size_t(1024)
+	bufSize := C.size_t(refnameMaxLength)
 	buf := (*C.char)(C.malloc(bufSize))
 	defer C.free(unsafe.Pointer(buf))
 

--- a/reference.go
+++ b/reference.go
@@ -512,7 +512,7 @@ func ReferenceNormalizeName(name string, flags ReferenceFormat) (string, error) 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	bufSize := C.ulong(1024)
+	bufSize := C.size_t(1024)
 	buf := (*C.char)(C.malloc(bufSize))
 	defer C.free(unsafe.Pointer(buf))
 

--- a/reference.go
+++ b/reference.go
@@ -491,7 +491,7 @@ func ReferenceIsValidName(name string) bool {
 
 const (
 	// This should match GIT_REFNAME_MAX in src/refs.h
-	refnameMaxLength = 1024
+	_refnameMaxLength = C.size_t(1024)
 )
 
 type ReferenceFormat uint
@@ -514,14 +514,13 @@ func ReferenceNormalizeName(name string, flags ReferenceFormat) (string, error) 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	bufSize := C.size_t(refnameMaxLength)
-	buf := (*C.char)(C.malloc(bufSize))
+	buf := (*C.char)(C.malloc(_refnameMaxLength))
 	defer C.free(unsafe.Pointer(buf))
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_reference_normalize_name(buf, bufSize, cname, C.uint(flags))
+	ecode := C.git_reference_normalize_name(buf, _refnameMaxLength, cname, C.uint(flags))
 	if ecode < 0 {
 		return "", MakeGitError(ecode)
 	}

--- a/reference.go
+++ b/reference.go
@@ -504,9 +504,6 @@ const (
 // characters and collapsing runs of adjacent slashes between name components
 // into a single slash.
 //
-// Once normalized, if the reference name is valid, it will be returned in the
-// user allocated buffer.
-//
 // See git_reference_symbolic_create() for rules about valid names.
 func ReferenceNormalizeName(name string, flags ReferenceFormat) (string, error) {
 	cname := C.CString(name)

--- a/reference.go
+++ b/reference.go
@@ -516,6 +516,9 @@ func ReferenceNormalizeName(name string, flags ReferenceFormat) (string, error) 
 	buf := (*C.char)(C.malloc(bufSize))
 	defer C.free(unsafe.Pointer(buf))
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ecode := C.git_reference_normalize_name(buf, bufSize, cname, C.uint(flags))
 	if ecode < 0 {
 		return "", MakeGitError(ecode)

--- a/reference_test.go
+++ b/reference_test.go
@@ -231,14 +231,14 @@ func TestReferenceNormalizeName(t *testing.T) {
 	checkFatal(t, err)
 
 	if ref != "refs/heads/master" {
-		t.Errorf("ReferenceNormalizeName(%q) = %q; want %q", "refs/heads//master", ref, want)
+		t.Errorf("ReferenceNormalizeName(%q) = %q; want %q", "refs/heads//master", ref, "refs/heads/master")
 	}
 
 	ref, err = ReferenceNormalizeName("master", ReferenceFormatAllowOnelevel|ReferenceFormatRefspecShorthand)
 	checkFatal(t, err)
 
 	if ref != "master" {
-		t.Errorf("master should be normalized correctly")
+		t.Errorf("ReferenceNormalizeName(%q) = %q; want %q", "master", ref, "master")
 	}
 
 	ref, err = ReferenceNormalizeName("foo^", ReferenceFormatNormal)

--- a/reference_test.go
+++ b/reference_test.go
@@ -224,6 +224,29 @@ func TestReferenceIsValidName(t *testing.T) {
 	}
 }
 
+func TestReferenceNormalizeName(t *testing.T) {
+	t.Parallel()
+
+	ref, err := ReferenceNormalizeName("refs/heads//master", ReferenceFormatNormal)
+	checkFatal(t, err)
+
+	if ref != "refs/heads/master" {
+		t.Errorf("refs/heads//master should be normalized correctly")
+	}
+
+	ref, err = ReferenceNormalizeName("master", ReferenceFormatAllowOnelevel|ReferenceFormatRefspecShorthand)
+	checkFatal(t, err)
+
+	if ref != "master" {
+		t.Errorf("master should be normalized correctly")
+	}
+
+	ref, err = ReferenceNormalizeName("foo^", ReferenceFormatNormal)
+	if !IsErrorCode(err, ErrInvalidSpec) {
+		t.Errorf("foo^ should be invalid")
+	}
+}
+
 func compareStringList(t *testing.T, expected, actual []string) {
 	for i, v := range expected {
 		if actual[i] != v {

--- a/reference_test.go
+++ b/reference_test.go
@@ -231,7 +231,7 @@ func TestReferenceNormalizeName(t *testing.T) {
 	checkFatal(t, err)
 
 	if ref != "refs/heads/master" {
-		t.Errorf("refs/heads//master should be normalized correctly")
+		t.Errorf("ReferenceNormalizeName(%q) = %q; want %q", "refs/heads//master", ref, want)
 	}
 
 	ref, err = ReferenceNormalizeName("master", ReferenceFormatAllowOnelevel|ReferenceFormatRefspecShorthand)


### PR DESCRIPTION
Not sure about the buffer allocation for passing to `git_reference_normalize_name`: Is using `malloc` correct? Is the size correct, or should it be a loop with retries with some increasing buffer size (But the function doesn't seem to tell you how big it should be...)?