### PR TITLE
[release-1.0] Relax libgit2 minor version check (#696)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
   build-system-dynamic:
     strategy:
       fail-fast: false
+      matrix:
+        libgit2: [ '1.0.0', '1.0.1', '1.1.0' ]
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04
@@ -103,10 +105,10 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
-    - name: Build libgit2
+    - name: Build libgit2 ${{ matrix.libgit2 }}
       run: |
         git submodule update --init
-        sudo ./script/build-libgit2.sh --dynamic --system
+        sudo env BUILD_LIBGIT_REF=v${{ matrix.libgit2 }} ./script/build-libgit2.sh --dynamic --system
     - name: Test
       run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libgit2: [ '1.0.0', '1.0.1', '1.1.0' ]
+        libgit2: [ '1.0.0', '1.1.0' ]
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04

--- a/git_bundled_static.go
+++ b/git_bundled_static.go
@@ -9,8 +9,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0
-# error "Invalid libgit2 version; this git2go supports libgit2 >= v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0 || LIBGIT2_VER_MINOR > 1
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.0.0 and v1.1.0".
 #endif
 */
 import "C"

--- a/git_bundled_static.go
+++ b/git_bundled_static.go
@@ -9,8 +9,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
-# error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0
+# error "Invalid libgit2 version; this git2go supports libgit2 >= v1.0"
 #endif
 */
 import "C"

--- a/git_system_dynamic.go
+++ b/git_system_dynamic.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0
-# error "Invalid libgit2 version; this git2go supports libgit2 >= v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0 || LIBGIT2_VER_MINOR > 1
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.0.0 and v1.1.0".
 #endif
 */
 import "C"

--- a/git_system_dynamic.go
+++ b/git_system_dynamic.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
-# error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0
+# error "Invalid libgit2 version; this git2go supports libgit2 >= v1.0"
 #endif
 */
 import "C"

--- a/git_system_static.go
+++ b/git_system_static.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0
-# error "Invalid libgit2 version; this git2go supports libgit2 >= v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0 || LIBGIT2_VER_MINOR > 1
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.0.0 and v1.1.0".
 #endif
 */
 import "C"

--- a/git_system_static.go
+++ b/git_system_static.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR != 0
-# error "Invalid libgit2 version; this git2go supports libgit2 v1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 0
+# error "Invalid libgit2 version; this git2go supports libgit2 >= v1.0"
 #endif
 */
 import "C"

--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -46,6 +46,11 @@ if [ -z "${BUILD_SHARED_LIBS}" ]; then
 	usage
 fi
 
+if [ -n "${BUILD_LIBGIT_REF}" ]; then
+	git -C "${VENDORED_PATH}" checkout "${BUILD_LIBGIT_REF}"
+	trap "git submodule update --init" EXIT
+fi
+
 if [ "${BUILD_SYSTEM}" = "ON" ]; then
 	BUILD_INSTALL_PREFIX=${SYSTEM_INSTALL_PREFIX-"/usr"}
 else


### PR DESCRIPTION
Backport of #696.

----

The major version must still be an exact match since libgit2 uses
semantic versioning and changes to the major number indicate backwards
incompatible changes to the API.

Fixes: #695
(cherry picked from commit 1fabe95fb7275df980ff6ab03fb85eac91c5849d)