### PR TITLE
Refactor all callbacks

### DIFF
--- a/checkout.go
+++ b/checkout.go
@@ -3,10 +3,11 @@ package git
 /*
 #include <git2.h>
 
-extern void _go_git_populate_checkout_cb(git_checkout_options *opts);
+extern void _go_git_populate_checkout_callbacks(git_checkout_options *opts);
 */
 import "C"
 import (
+	"errors"
 	"os"
 	"runtime"
 	"unsafe"
@@ -75,10 +76,10 @@ func checkoutOptionsFromC(c *C.git_checkout_options) CheckoutOptions {
 		NotifyFlags:    CheckoutNotifyType(c.notify_flags),
 	}
 	if c.notify_payload != nil {
-		opts.NotifyCallback = pointerHandles.Get(c.notify_payload).(*CheckoutOptions).NotifyCallback
+		opts.NotifyCallback = pointerHandles.Get(c.notify_payload).(*checkoutCallbackData).options.NotifyCallback
 	}
 	if c.progress_payload != nil {
-		opts.ProgressCallback = pointerHandles.Get(c.progress_payload).(*CheckoutOptions).ProgressCallback
+		opts.ProgressCallback = pointerHandles.Get(c.progress_payload).(*checkoutCallbackData).options.ProgressCallback
 	}
 	if c.target_directory != nil {
 		opts.TargetDirectory = C.GoString(c.target_directory)
@@ -86,19 +87,26 @@ func checkoutOptionsFromC(c *C.git_checkout_options) CheckoutOptions {
 	return opts
 }
 
-func (opts *CheckoutOptions) toC() *C.git_checkout_options {
+func (opts *CheckoutOptions) toC(errorTarget *error) *C.git_checkout_options {
 	if opts == nil {
 		return nil
 	}
-	c := C.git_checkout_options{}
-	populateCheckoutOptions(&c, opts)
-	return &c
+	return populateCheckoutOptions(&C.git_checkout_options{}, opts, errorTarget)
+}
+
+type checkoutCallbackData struct {
+	options     *CheckoutOptions
+	errorTarget *error
 }
 
 //export checkoutNotifyCallback
-func checkoutNotifyCallback(why C.git_checkout_notify_t, cpath *C.char, cbaseline, ctarget, cworkdir, data unsafe.Pointer) int {
-	if data == nil {
-		return 0
+func checkoutNotifyCallback(
+	why C.git_checkout_notify_t,
+	cpath *C.char,
+	cbaseline, ctarget, cworkdir, handle unsafe.Pointer,
+) C.int {
+	if handle == nil {
+		return C.int(ErrorCodeOK)
 	}
 	path := C.GoString(cpath)
 	var baseline, target, workdir DiffFile
@@ -111,26 +119,35 @@ func checkoutNotifyCallback(why C.git_checkout_notify_t, cpath *C.char, cbaselin
 	if cworkdir != nil {
 		workdir = diffFileFromC((*C.git_diff_file)(cworkdir))
 	}
-	opts := pointerHandles.Get(data).(*CheckoutOptions)
-	if opts.NotifyCallback == nil {
-		return 0
+	data := pointerHandles.Get(handle).(*checkoutCallbackData)
+	if data.options.NotifyCallback == nil {
+		return C.int(ErrorCodeOK)
 	}
-	return int(opts.NotifyCallback(CheckoutNotifyType(why), path, baseline, target, workdir))
+	ret := data.options.NotifyCallback(CheckoutNotifyType(why), path, baseline, target, workdir)
+	if ret < 0 {
+		*data.errorTarget = errors.New(ErrorCode(ret).String())
+		return C.int(ErrorCodeUser)
+	}
+	return C.int(ErrorCodeOK)
 }
 
 //export checkoutProgressCallback
-func checkoutProgressCallback(path *C.char, completed_steps, total_steps C.size_t, data unsafe.Pointer) int {
-	opts := pointerHandles.Get(data).(*CheckoutOptions)
-	if opts.ProgressCallback == nil {
-		return 0
+func checkoutProgressCallback(
+	path *C.char,
+	completed_steps, total_steps C.size_t,
+	handle unsafe.Pointer,
+) {
+	data := pointerHandles.Get(handle).(*checkoutCallbackData)
+	if data.options.ProgressCallback == nil {
+		return
 	}
-	return int(opts.ProgressCallback(C.GoString(path), uint(completed_steps), uint(total_steps)))
+	data.options.ProgressCallback(C.GoString(path), uint(completed_steps), uint(total_steps))
 }
 
 // Convert the CheckoutOptions struct to the corresponding
 // C-struct. Returns a pointer to ptr, or nil if opts is nil, in order
 // to help with what to pass.
-func populateCheckoutOptions(ptr *C.git_checkout_options, opts *CheckoutOptions) *C.git_checkout_options {
+func populateCheckoutOptions(ptr *C.git_checkout_options, opts *CheckoutOptions, errorTarget *error) *C.git_checkout_options {
 	if opts == nil {
 		return nil
 	}
@@ -142,14 +159,18 @@ func populateCheckoutOptions(ptr *C.git_checkout_options, opts *CheckoutOptions)
 	ptr.file_mode = C.uint(opts.FileMode.Perm())
 	ptr.notify_flags = C.uint(opts.NotifyFlags)
 	if opts.NotifyCallback != nil || opts.ProgressCallback != nil {
-		C._go_git_populate_checkout_cb(ptr)
-	}
-	payload := pointerHandles.Track(opts)
-	if opts.NotifyCallback != nil {
-		ptr.notify_payload = payload
-	}
-	if opts.ProgressCallback != nil {
-		ptr.progress_payload = payload
+		C._go_git_populate_checkout_callbacks(ptr)
+		data := &checkoutCallbackData{
+			options:     opts,
+			errorTarget: errorTarget,
+		}
+		payload := pointerHandles.Track(data)
+		if opts.NotifyCallback != nil {
+			ptr.notify_payload = payload
+		}
+		if opts.ProgressCallback != nil {
+			ptr.progress_payload = payload
+		}
 	}
 	if opts.TargetDirectory != "" {
 		ptr.target_directory = C.CString(opts.TargetDirectory)
@@ -176,6 +197,8 @@ func freeCheckoutOptions(ptr *C.git_checkout_options) {
 	}
 	if ptr.notify_payload != nil {
 		pointerHandles.Untrack(ptr.notify_payload)
+	} else if ptr.progress_payload != nil {
+		pointerHandles.Untrack(ptr.progress_payload)
 	}
 }
 
@@ -185,11 +208,16 @@ func (v *Repository) CheckoutHead(opts *CheckoutOptions) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cOpts := opts.toC()
+	var err error
+	cOpts := opts.toC(&err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_head(v.ptr, cOpts)
 	runtime.KeepAlive(v)
+
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
+	}
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -209,11 +237,15 @@ func (v *Repository) CheckoutIndex(index *Index, opts *CheckoutOptions) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cOpts := opts.toC()
+	var err error
+	cOpts := opts.toC(&err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_index(v.ptr, iptr, cOpts)
 	runtime.KeepAlive(v)
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
+	}
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -225,11 +257,16 @@ func (v *Repository) CheckoutTree(tree *Tree, opts *CheckoutOptions) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cOpts := opts.toC()
+	var err error
+	cOpts := opts.toC(&err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_tree(v.ptr, tree.ptr, cOpts)
 	runtime.KeepAlive(v)
+	runtime.KeepAlive(tree)
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
+	}
 	if ret < 0 {
 		return MakeGitError(ret)
 	}

--- a/clone.go
+++ b/clone.go
@@ -3,10 +3,11 @@ package git
 /*
 #include <git2.h>
 
-extern void _go_git_populate_remote_cb(git_clone_options *opts);
+extern void _go_git_populate_clone_callbacks(git_clone_options *opts);
 */
 import "C"
 import (
+	"errors"
 	"runtime"
 	"unsafe"
 )
@@ -28,20 +29,23 @@ func Clone(url string, path string, options *CloneOptions) (*Repository, error) 
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 
-	copts := (*C.git_clone_options)(C.calloc(1, C.size_t(unsafe.Sizeof(C.git_clone_options{}))))
-	populateCloneOptions(copts, options)
-	defer freeCloneOptions(copts)
+	var err error
+	cOptions := populateCloneOptions(&C.git_clone_options{}, options, &err)
+	defer freeCloneOptions(cOptions)
 
 	if len(options.CheckoutBranch) != 0 {
-		copts.checkout_branch = C.CString(options.CheckoutBranch)
+		cOptions.checkout_branch = C.CString(options.CheckoutBranch)
 	}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	var ptr *C.git_repository
-	ret := C.git_clone(&ptr, curl, cpath, copts)
+	ret := C.git_clone(&ptr, curl, cpath, cOptions)
 
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return nil, err
+	}
 	if ret < 0 {
 		return nil, MakeGitError(ret)
 	}
@@ -50,47 +54,69 @@ func Clone(url string, path string, options *CloneOptions) (*Repository, error) 
 }
 
 //export remoteCreateCallback
-func remoteCreateCallback(cremote unsafe.Pointer, crepo unsafe.Pointer, cname, curl *C.char, payload unsafe.Pointer) C.int {
+func remoteCreateCallback(
+	cremote unsafe.Pointer,
+	crepo unsafe.Pointer,
+	cname, curl *C.char,
+	payload unsafe.Pointer,
+) C.int {
 	name := C.GoString(cname)
 	url := C.GoString(curl)
 	repo := newRepositoryFromC((*C.git_repository)(crepo))
 	// We don't own this repository, so make sure we don't try to free it
 	runtime.SetFinalizer(repo, nil)
 
-	if opts, ok := pointerHandles.Get(payload).(CloneOptions); ok {
-		remote, errorCode := opts.RemoteCreateCallback(repo, name, url)
-		// clear finalizer as the calling C function will
-		// free the remote itself
-		runtime.SetFinalizer(remote, nil)
-
-		if errorCode == ErrorCodeOK && remote != nil {
-			cptr := (**C.git_remote)(cremote)
-			*cptr = remote.ptr
-		} else if errorCode == ErrorCodeOK && remote == nil {
-			panic("no remote created by callback")
-		}
-
-		return C.int(errorCode)
-	} else {
+	data, ok := pointerHandles.Get(payload).(*cloneCallbackData)
+	if !ok {
 		panic("invalid remote create callback")
 	}
+
+	remote, ret := data.options.RemoteCreateCallback(repo, name, url)
+	// clear finalizer as the calling C function will
+	// free the remote itself
+	runtime.SetFinalizer(remote, nil)
+
+	if ret < 0 {
+		*data.errorTarget = errors.New(ErrorCode(ret).String())
+		return C.int(ErrorCodeUser)
+	}
+
+	if remote == nil {
+		panic("no remote created by callback")
+	}
+
+	cptr := (**C.git_remote)(cremote)
+	*cptr = remote.ptr
+
+	return C.int(ErrorCodeOK)
 }
 
-func populateCloneOptions(ptr *C.git_clone_options, opts *CloneOptions) {
+type cloneCallbackData struct {
+	options     *CloneOptions
+	errorTarget *error
+}
+
+func populateCloneOptions(ptr *C.git_clone_options, opts *CloneOptions, errorTarget *error) *C.git_clone_options {
 	C.git_clone_options_init(ptr, C.GIT_CLONE_OPTIONS_VERSION)
 
 	if opts == nil {
-		return
+		return nil
 	}
-	populateCheckoutOptions(&ptr.checkout_opts, opts.CheckoutOpts)
+	populateCheckoutOptions(&ptr.checkout_opts, opts.CheckoutOpts, errorTarget)
 	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
 	ptr.bare = cbool(opts.Bare)
 
 	if opts.RemoteCreateCallback != nil {
+		data := &cloneCallbackData{
+			options:     opts,
+			errorTarget: errorTarget,
+		}
 		// Go v1.1 does not allow to assign a C function pointer
-		C._go_git_populate_remote_cb(ptr)
-		ptr.remote_cb_payload = pointerHandles.Track(*opts)
+		C._go_git_populate_clone_callbacks(ptr)
+		ptr.remote_cb_payload = pointerHandles.Track(data)
 	}
+
+	return ptr
 }
 
 func freeCloneOptions(ptr *C.git_clone_options) {
@@ -105,5 +131,4 @@ func freeCloneOptions(ptr *C.git_clone_options) {
 	}
 
 	C.free(unsafe.Pointer(ptr.checkout_branch))
-	C.free(unsafe.Pointer(ptr))
 }

--- a/git.go
+++ b/git.go
@@ -330,6 +330,17 @@ func ucbool(b bool) C.uint {
 	return C.uint(0)
 }
 
+func setCallbackError(errorMessage **C.char, err error) C.int {
+	if err != nil {
+		*errorMessage = C.CString(err.Error())
+		if gitError, ok := err.(*GitError); ok {
+			return C.int(gitError.Code)
+		}
+		return C.int(ErrorCodeUser)
+	}
+	return C.int(ErrorCodeOK)
+}
+
 func Discover(start string, across_fs bool, ceiling_dirs []string) (string, error) {
 	ceildirs := C.CString(strings.Join(ceiling_dirs, string(C.GIT_PATH_LIST_SEPARATOR)))
 	defer C.free(unsafe.Pointer(ceildirs))

--- a/remote_test.go
+++ b/remote_test.go
@@ -30,7 +30,7 @@ func assertHostname(cert *Certificate, valid bool, hostname string, t *testing.T
 		return ErrorCodeUser
 	}
 
-	return 0
+	return ErrorCodeOK
 }
 
 func TestCertificateCheck(t *testing.T) {

--- a/stash.go
+++ b/stash.go
@@ -3,7 +3,7 @@ package git
 /*
 #include <git2.h>
 
-extern void _go_git_setup_stash_apply_progress_callbacks(git_stash_apply_options *opts);
+extern void _go_git_populate_stash_apply_callbacks(git_stash_apply_options *opts);
 extern int _go_git_stash_foreach(git_repository *repo, void *payload);
 */
 import "C"
@@ -113,28 +113,28 @@ const (
 
 // StashApplyProgressCallback is the apply operation notification callback.
 type StashApplyProgressCallback func(progress StashApplyProgress) error
-
-type stashApplyProgressData struct {
-	Callback StashApplyProgressCallback
-	Error    error
+type stashApplyProgressCallbackData struct {
+	callback    StashApplyProgressCallback
+	errorTarget *error
 }
 
-//export stashApplyProgressCb
-func stashApplyProgressCb(progress C.git_stash_apply_progress_t, handle unsafe.Pointer) int {
+//export stashApplyProgressCallback
+func stashApplyProgressCallback(progress C.git_stash_apply_progress_t, handle unsafe.Pointer) C.int {
 	payload := pointerHandles.Get(handle)
-	data, ok := payload.(*stashApplyProgressData)
+	data, ok := payload.(*stashApplyProgressCallbackData)
 	if !ok {
 		panic("could not retrieve data for handle")
 	}
-
-	if data != nil {
-		err := data.Callback(StashApplyProgress(progress))
-		if err != nil {
-			data.Error = err
-			return C.GIT_EUSER
-		}
+	if data == nil || data.callback == nil {
+		return C.int(ErrorCodeOK)
 	}
-	return 0
+
+	err := data.callback(StashApplyProgress(progress))
+	if err != nil {
+		*data.errorTarget = err
+		return C.int(ErrorCodeUser)
+	}
+	return C.int(ErrorCodeOK)
 }
 
 // StashApplyOptions represents options to control the apply operation.
@@ -161,38 +161,34 @@ func DefaultStashApplyOptions() (StashApplyOptions, error) {
 	}, nil
 }
 
-func (opts *StashApplyOptions) toC() (
-	optsC *C.git_stash_apply_options, progressData *stashApplyProgressData) {
-
-	if opts != nil {
-		progressData = &stashApplyProgressData{
-			Callback: opts.ProgressCallback,
-		}
-
-		optsC = &C.git_stash_apply_options{
-			version: C.GIT_STASH_APPLY_OPTIONS_VERSION,
-			flags:   C.uint32_t(opts.Flags),
-		}
-		populateCheckoutOptions(&optsC.checkout_options, &opts.CheckoutOptions)
-		if opts.ProgressCallback != nil {
-			C._go_git_setup_stash_apply_progress_callbacks(optsC)
-			optsC.progress_payload = pointerHandles.Track(progressData)
-		}
+func (opts *StashApplyOptions) toC(errorTarget *error) *C.git_stash_apply_options {
+	if opts == nil {
+		return nil
 	}
-	return
-}
-
-// should be called after every call to toC() as deferred.
-func untrackStashApplyOptionsCallback(optsC *C.git_stash_apply_options) {
-	if optsC != nil && optsC.progress_payload != nil {
-		pointerHandles.Untrack(optsC.progress_payload)
+	optsC := &C.git_stash_apply_options{
+		version: C.GIT_STASH_APPLY_OPTIONS_VERSION,
+		flags:   C.uint32_t(opts.Flags),
 	}
+	populateCheckoutOptions(&optsC.checkout_options, &opts.CheckoutOptions, errorTarget)
+	if opts.ProgressCallback != nil {
+		progressData := &stashApplyProgressCallbackData{
+			callback:    opts.ProgressCallback,
+			errorTarget: errorTarget,
+		}
+		C._go_git_populate_stash_apply_callbacks(optsC)
+		optsC.progress_payload = pointerHandles.Track(progressData)
+	}
+	return optsC
 }
 
 func freeStashApplyOptions(optsC *C.git_stash_apply_options) {
-	if optsC != nil {
-		freeCheckoutOptions(&optsC.checkout_options)
+	if optsC == nil {
+		return
 	}
+	if optsC.progress_payload != nil {
+		pointerHandles.Untrack(optsC.progress_payload)
+	}
+	freeCheckoutOptions(&optsC.checkout_options)
 }
 
 // Apply applies a single stashed state from the stash list.
@@ -220,8 +216,8 @@ func freeStashApplyOptions(optsC *C.git_stash_apply_options) {
 //
 // Error codes can be interogated with IsErrorCode(err, ErrorCodeNotFound).
 func (c *StashCollection) Apply(index int, opts StashApplyOptions) error {
-	optsC, progressData := opts.toC()
-	defer untrackStashApplyOptionsCallback(optsC)
+	var err error
+	optsC := opts.toC(&err)
 	defer freeStashApplyOptions(optsC)
 
 	runtime.LockOSThread()
@@ -229,8 +225,8 @@ func (c *StashCollection) Apply(index int, opts StashApplyOptions) error {
 
 	ret := C.git_stash_apply(c.repo.ptr, C.size_t(index), optsC)
 	runtime.KeepAlive(c)
-	if ret == C.GIT_EUSER {
-		return progressData.Error
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
 	}
 	if ret < 0 {
 		return MakeGitError(ret)
@@ -245,26 +241,25 @@ func (c *StashCollection) Apply(index int, opts StashApplyOptions) error {
 // 'message' is the message used when creating the stash and 'id'
 // is the commit id of the stash.
 type StashCallback func(index int, message string, id *Oid) error
-
 type stashCallbackData struct {
-	Callback StashCallback
-	Error    error
+	callback    StashCallback
+	errorTarget *error
 }
 
-//export stashForeachCb
-func stashForeachCb(index C.size_t, message *C.char, id *C.git_oid, handle unsafe.Pointer) int {
+//export stashForeachCallback
+func stashForeachCallback(index C.size_t, message *C.char, id *C.git_oid, handle unsafe.Pointer) C.int {
 	payload := pointerHandles.Get(handle)
 	data, ok := payload.(*stashCallbackData)
 	if !ok {
 		panic("could not retrieve data for handle")
 	}
 
-	err := data.Callback(int(index), C.GoString(message), newOidFromC(id))
+	err := data.callback(int(index), C.GoString(message), newOidFromC(id))
 	if err != nil {
-		data.Error = err
-		return C.GIT_EUSER
+		*data.errorTarget = err
+		return C.int(ErrorCodeUser)
 	}
-	return 0
+	return C.int(ErrorCodeOK)
 }
 
 // Foreach loops over all the stashed states and calls the callback
@@ -272,10 +267,11 @@ func stashForeachCb(index C.size_t, message *C.char, id *C.git_oid, handle unsaf
 //
 // If callback returns an error, this will stop looping.
 func (c *StashCollection) Foreach(callback StashCallback) error {
+	var err error
 	data := stashCallbackData{
-		Callback: callback,
+		callback:    callback,
+		errorTarget: &err,
 	}
-
 	handle := pointerHandles.Track(&data)
 	defer pointerHandles.Untrack(handle)
 
@@ -284,8 +280,8 @@ func (c *StashCollection) Foreach(callback StashCallback) error {
 
 	ret := C._go_git_stash_foreach(c.repo.ptr, handle)
 	runtime.KeepAlive(c)
-	if ret == C.GIT_EUSER {
-		return data.Error
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
 	}
 	if ret < 0 {
 		return MakeGitError(ret)
@@ -323,8 +319,8 @@ func (c *StashCollection) Drop(index int) error {
 // Returns error code ErrorCodeNotFound if there's no stashed
 // state for the given index.
 func (c *StashCollection) Pop(index int, opts StashApplyOptions) error {
-	optsC, progressData := opts.toC()
-	defer untrackStashApplyOptionsCallback(optsC)
+	var err error
+	optsC := opts.toC(&err)
 	defer freeStashApplyOptions(optsC)
 
 	runtime.LockOSThread()
@@ -332,8 +328,8 @@ func (c *StashCollection) Pop(index int, opts StashApplyOptions) error {
 
 	ret := C.git_stash_pop(c.repo.ptr, C.size_t(index), optsC)
 	runtime.KeepAlive(c)
-	if ret == C.GIT_EUSER {
-		return progressData.Error
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
 	}
 	if ret < 0 {
 		return MakeGitError(ret)

--- a/wrapper.c
+++ b/wrapper.c
@@ -1,36 +1,149 @@
 #include "_cgo_export.h"
+
 #include <git2.h>
 #include <git2/sys/odb_backend.h>
 #include <git2/sys/refdb_backend.h>
 #include <git2/sys/cred.h>
 
-typedef int (*gogit_submodule_cbk)(git_submodule *sm, const char *name, void *payload);
+// There are two ways in which to declare a callback:
+//
+// * If there is a guarantee that the callback will always be called within the
+//   same stack (e.g. by passing the callback directly into a function / into a
+//   struct that goes into a function), the following pattern is preferred,
+//   which preserves the error object as-is:
+//
+//   // myfile.go
+//   type FooCallback func(...) (..., error)
+//   type FooCallbackData struct {
+//     callback    FooCallback
+//     errorTarget *error
+//   }
+//
+//   //export fooCallback
+//   func fooCallback(..., handle unsafe.Pointer) C.int {
+//     payload := pointerHandles.Get(handle)
+//     data := payload.(*fooCallbackData)
+//     ...
+//     err := data.callback(...)
+//     if err != nil {
+//       *data.errorTarget = err
+//       return C.int(ErrorCodeUser)
+//     }
+//     return C.int(ErrorCodeOK)
+//   }
+//
+//   func MyFunction(... callback FooCallback) error {
+//    var err error
+//    data := fooCallbackData{
+//      callback:    callback,
+//      errorTarget: &err,
+//    }
+//    handle := pointerHandles.Track(&data)
+//    defer pointerHandles.Untrack(handle)
+//
+//    runtime.LockOSThread()
+//    defer runtime.UnlockOSThread()
+//
+//    ret := C._go_git_my_function(..., handle)
+//    if ret == C.int(ErrorCodeUser) && err != nil {
+//      return err
+//    }
+//    if ret < 0 {
+//      return MakeGitError(ret)
+//    }
+//    return nil
+//   }
+//
+//   // wrapper.c
+//   int _go_git_my_function(..., void *payload)
+//   {
+//     return git_my_function(..., (git_foo_cb)&fooCallback, payload);
+//   }
+//
+// * Otherwise, if the same callback can be invoked from multiple functions or
+//   from different stacks (e.g. when passing the callback to an object), a
+//   different pattern should be used instead, which has the downside of losing
+//   the original error object and converting it to a GitError:
+//
+//   // myfile.go
+//   type FooCallback func(...) (..., error)
+//
+//   //export fooCallback
+//   func fooCallback(errorMessage **C.char, ..., handle unsafe.Pointer) C.int {
+//     callback := pointerHandles.Get(data).(*FooCallback)
+//     ...
+//     err := callback(...)
+//     if err != nil {
+//       return setCallbackError(errorMessage, err)
+//     }
+//     return C.int(ErrorCodeOK)
+//   }
+//
+//   // wrapper.c
+//   static int foo_callback(...)
+//   {
+//     char *error_message = NULL;
+//     const int ret = fooCallback(&error_message, ...);
+//     return set_callback_error(error_message, ret);
+//   }
 
-void _go_git_populate_apply_cb(git_apply_options *options)
+/**
+ * Sets the thread-local error to the provided string. This needs to happen in
+ * C because Go might change Goroutines _just_ before returning, which would
+ * lose the contents of the error message.
+ */
+static int set_callback_error(char *error_message, int ret)
 {
-	options->delta_cb = (git_apply_delta_cb)deltaApplyCallback;
-	options->hunk_cb = (git_apply_hunk_cb)hunkApplyCallback;
+	if (error_message != NULL) {
+		if (ret < 0)
+			git_error_set_str(GIT_ERROR_CALLBACK, error_message);
+		free(error_message);
+	}
+	return ret;
 }
 
-void _go_git_populate_commit_sign_cb(git_rebase_options *opts)
+void _go_git_populate_apply_callbacks(git_apply_options *options)
 {
-	opts->signing_cb = (git_commit_signing_cb)commitSignCallback;
+	options->delta_cb = (git_apply_delta_cb)&deltaApplyCallback;
+	options->hunk_cb = (git_apply_hunk_cb)&hunkApplyCallback;
 }
 
-void _go_git_populate_remote_cb(git_clone_options *opts)
+static int commit_signing_callback(
+		git_buf *signature,
+		git_buf *signature_field,
+		const char *commit_contents,
+		void *payload)
 {
-	opts->remote_cb = (git_remote_create_cb)remoteCreateCallback;
+	char *error_message = NULL;
+	const int ret = commitSigningCallback(
+			&error_message,
+			signature,
+			signature_field,
+			(char *)commit_contents,
+			payload
+	);
+	return set_callback_error(error_message, ret);
 }
 
-void _go_git_populate_checkout_cb(git_checkout_options *opts)
+void _go_git_populate_rebase_callbacks(git_rebase_options *opts)
 {
-	opts->notify_cb = (git_checkout_notify_cb)checkoutNotifyCallback;
-	opts->progress_cb = (git_checkout_progress_cb)checkoutProgressCallback;
+	opts->signing_cb = commit_signing_callback;
+}
+
+void _go_git_populate_clone_callbacks(git_clone_options *opts)
+{
+	opts->remote_cb = (git_remote_create_cb)&remoteCreateCallback;
+}
+
+void _go_git_populate_checkout_callbacks(git_checkout_options *opts)
+{
+	opts->notify_cb = (git_checkout_notify_cb)&checkoutNotifyCallback;
+	opts->progress_cb = (git_checkout_progress_cb)&checkoutProgressCallback;
 }
 
 int _go_git_visit_submodule(git_repository *repo, void *fct)
 {
-	  return git_submodule_foreach(repo, (gogit_submodule_cbk)&submoduleCallback, fct);
+	return git_submodule_foreach(repo, (git_submodule_cb)&submoduleCallback, fct);
 }
 
 int _go_git_treewalk(git_tree *tree, git_treewalk_mode mode, void *ptr)
@@ -40,28 +153,26 @@ int _go_git_treewalk(git_tree *tree, git_treewalk_mode mode, void *ptr)
 
 int _go_git_packbuilder_foreach(git_packbuilder *pb, void *payload)
 {
-    return git_packbuilder_foreach(pb, (git_packbuilder_foreach_cb)&packbuilderForEachCb, payload);
+	return git_packbuilder_foreach(pb, (git_packbuilder_foreach_cb)&packbuilderForEachCallback, payload);
 }
 
 int _go_git_odb_foreach(git_odb *db, void *payload)
 {
-    return git_odb_foreach(db, (git_odb_foreach_cb)&odbForEachCb, payload);
+	return git_odb_foreach(db, (git_odb_foreach_cb)&odbForEachCallback, payload);
 }
 
 void _go_git_odb_backend_free(git_odb_backend *backend)
 {
-    if (backend->free)
-      backend->free(backend);
-
-    return;
+	if (!backend->free)
+		return;
+	backend->free(backend);
 }
 
 void _go_git_refdb_backend_free(git_refdb_backend *backend)
 {
-    if (backend->free)
-      backend->free(backend);
-
-    return;
+	if (!backend->free)
+		return;
+	backend->free(backend);
 }
 
 int _go_git_diff_foreach(git_diff *diff, int eachFile, int eachHunk, int eachLine, void *payload)
@@ -70,83 +181,210 @@ int _go_git_diff_foreach(git_diff *diff, int eachFile, int eachHunk, int eachLin
 	git_diff_hunk_cb hcb = NULL;
 	git_diff_line_cb lcb = NULL;
 
-	if (eachFile) {
-		fcb = (git_diff_file_cb)&diffForEachFileCb;
-	}
-
-	if (eachHunk) {
-		hcb = (git_diff_hunk_cb)&diffForEachHunkCb;
-	}
-
-	if (eachLine) {
-		lcb = (git_diff_line_cb)&diffForEachLineCb;
-	}
+	if (eachFile)
+		fcb = (git_diff_file_cb)&diffForEachFileCallback;
+	if (eachHunk)
+		hcb = (git_diff_hunk_cb)&diffForEachHunkCallback;
+	if (eachLine)
+		lcb = (git_diff_line_cb)&diffForEachLineCallback;
 
 	return git_diff_foreach(diff, fcb, NULL, hcb, lcb, payload);
 }
 
-int _go_git_diff_blobs(git_blob *old, const char *old_path, git_blob *new, const char *new_path, git_diff_options *opts, int eachFile, int eachHunk, int eachLine, void *payload)
+int _go_git_diff_blobs(
+		git_blob *old,
+		const char *old_path,
+		git_blob *new,
+		const char *new_path,
+		git_diff_options *opts,
+		int eachFile,
+		int eachHunk,
+		int eachLine,
+		void *payload)
 {
 	git_diff_file_cb fcb = NULL;
 	git_diff_hunk_cb hcb = NULL;
 	git_diff_line_cb lcb = NULL;
 
-	if (eachFile) {
-		fcb = (git_diff_file_cb)&diffForEachFileCb;
-	}
-
-	if (eachHunk) {
-		hcb = (git_diff_hunk_cb)&diffForEachHunkCb;
-	}
-
-	if (eachLine) {
-		lcb = (git_diff_line_cb)&diffForEachLineCb;
-	}
+	if (eachFile)
+		fcb = (git_diff_file_cb)&diffForEachFileCallback;
+	if (eachHunk)
+		hcb = (git_diff_hunk_cb)&diffForEachHunkCallback;
+	if (eachLine)
+		lcb = (git_diff_line_cb)&diffForEachLineCallback;
 
 	return git_diff_blobs(old, old_path, new, new_path, opts, fcb, NULL, hcb, lcb, payload);
 }
 
-void _go_git_setup_diff_notify_callbacks(git_diff_options *opts) {
-	opts->notify_cb = (git_diff_notify_cb)diffNotifyCb;
+void _go_git_setup_diff_notify_callbacks(git_diff_options *opts)
+{
+	opts->notify_cb = (git_diff_notify_cb)&diffNotifyCallback;
 }
 
-void _go_git_setup_callbacks(git_remote_callbacks *callbacks) {
-	typedef int (*completion_cb)(git_remote_completion_type type, void *data);
-	typedef int (*update_tips_cb)(const char *refname, const git_oid *a, const git_oid *b, void *data);
-	typedef int (*push_update_reference_cb)(const char *refname, const char *status, void *data);
-
-	callbacks->sideband_progress = (git_transport_message_cb)sidebandProgressCallback;
-	callbacks->completion = (completion_cb)completionCallback;
-	callbacks->credentials = (git_credential_acquire_cb)credentialsCallback;
-	callbacks->transfer_progress = (git_transfer_progress_cb)transferProgressCallback;
-	callbacks->update_tips = (update_tips_cb)updateTipsCallback;
-	callbacks->certificate_check = (git_transport_certificate_check_cb) certificateCheckCallback;
-	callbacks->pack_progress = (git_packbuilder_progress) packProgressCallback;
-	callbacks->push_transfer_progress = (git_push_transfer_progress) pushTransferProgressCallback;
-	callbacks->push_update_reference = (push_update_reference_cb) pushUpdateReferenceCallback;
+static int sideband_progress_callback(const char *str, int len, void *payload)
+{
+	char *error_message = NULL;
+	const int ret = sidebandProgressCallback(&error_message, (char *)str, len, payload);
+	return set_callback_error(error_message, ret);
 }
 
-int _go_git_index_add_all(git_index *index, const git_strarray *pathspec, unsigned int flags, void *callback) {
-	git_index_matched_path_cb cb = callback ? (git_index_matched_path_cb) &indexMatchedPathCallback : NULL;
+static int completion_callback(git_remote_completion_type completion_type, void *data)
+{
+	char *error_message = NULL;
+	const int ret = completionCallback(&error_message, completion_type, data);
+	return set_callback_error(error_message, ret);
+}
+
+static int credentials_callback(
+		git_credential **cred,
+		const char *url,
+		const char *username_from_url,
+		unsigned int allowed_types,
+		void *data)
+{
+	char *error_message = NULL;
+	const int ret = credentialsCallback(
+			&error_message,
+			cred,
+			(char *)url,
+			(char *)username_from_url,
+			allowed_types,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+static int transfer_progress_callback(const git_transfer_progress *stats, void *data)
+{
+	char *error_message = NULL;
+	const int ret = transferProgressCallback(
+			&error_message,
+			(git_transfer_progress *)stats,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+static int update_tips_callback(const char *refname, const git_oid *a, const git_oid *b, void *data)
+{
+	char *error_message = NULL;
+	const int ret = updateTipsCallback(
+			&error_message,
+			(char *)refname,
+			(git_oid *)a,
+			(git_oid *)b,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+static int certificate_check_callback(git_cert *cert, int valid, const char *host, void *data)
+{
+	char *error_message = NULL;
+	const int ret = certificateCheckCallback(
+			&error_message,
+			cert,
+			valid,
+			(char *)host,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+static int pack_progress_callback(int stage, unsigned int current, unsigned int total, void *data)
+{
+	char *error_message = NULL;
+	const int ret = packProgressCallback(
+			&error_message,
+			stage,
+			current,
+			total,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+static int push_transfer_progress_callback(
+		unsigned int current,
+		unsigned int total,
+		size_t bytes,
+		void *data)
+{
+	char *error_message = NULL;
+	const int ret = pushTransferProgressCallback(
+			&error_message,
+			current,
+			total,
+			bytes,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+static int push_update_reference_callback(const char *refname, const char *status, void *data)
+{
+	char *error_message = NULL;
+	const int ret = pushUpdateReferenceCallback(
+			&error_message,
+			(char *)refname,
+			(char *)status,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+void _go_git_populate_remote_callbacks(git_remote_callbacks *callbacks)
+{
+	callbacks->sideband_progress = sideband_progress_callback;
+	callbacks->completion = completion_callback;
+	callbacks->credentials = credentials_callback;
+	callbacks->transfer_progress = transfer_progress_callback;
+	callbacks->update_tips = update_tips_callback;
+	callbacks->certificate_check = certificate_check_callback;
+	callbacks->pack_progress = pack_progress_callback;
+	callbacks->push_transfer_progress = push_transfer_progress_callback;
+	callbacks->push_update_reference = push_update_reference_callback;
+}
+
+int _go_git_index_add_all(git_index *index, const git_strarray *pathspec, unsigned int flags, void *callback)
+{
+	git_index_matched_path_cb cb = callback ? (git_index_matched_path_cb)&indexMatchedPathCallback : NULL;
 	return git_index_add_all(index, pathspec, flags, cb, callback);
 }
 
-int _go_git_index_update_all(git_index *index, const git_strarray *pathspec, void *callback) {
-	git_index_matched_path_cb cb = callback ? (git_index_matched_path_cb) &indexMatchedPathCallback : NULL;
+int _go_git_index_update_all(git_index *index, const git_strarray *pathspec, void *callback)
+{
+	git_index_matched_path_cb cb = callback ? (git_index_matched_path_cb)&indexMatchedPathCallback : NULL;
 	return git_index_update_all(index, pathspec, cb, callback);
 }
 
-int _go_git_index_remove_all(git_index *index, const git_strarray *pathspec, void *callback) {
-	git_index_matched_path_cb cb = callback ? (git_index_matched_path_cb) &indexMatchedPathCallback : NULL;
+int _go_git_index_remove_all(git_index *index, const git_strarray *pathspec, void *callback)
+{
+	git_index_matched_path_cb cb = callback ? (git_index_matched_path_cb)&indexMatchedPathCallback : NULL;
 	return git_index_remove_all(index, pathspec, cb, callback);
 }
 
 int _go_git_tag_foreach(git_repository *repo, void *payload)
 {
-    return git_tag_foreach(repo, (git_tag_foreach_cb)&gitTagForeachCb, payload);
+	return git_tag_foreach(repo, (git_tag_foreach_cb)&tagForeachCallback, payload);
 }
 
-int _go_git_merge_file(git_merge_file_result* out, char* ancestorContents, size_t ancestorLen, char* ancestorPath, unsigned int ancestorMode, char* oursContents, size_t oursLen, char* oursPath, unsigned int oursMode, char* theirsContents, size_t theirsLen, char* theirsPath, unsigned int theirsMode, git_merge_file_options* copts) {
+int _go_git_merge_file(
+		git_merge_file_result* out,
+		char* ancestorContents,
+		size_t ancestorLen,
+		char* ancestorPath,
+		unsigned int ancestorMode,
+		char* oursContents,
+		size_t oursLen,
+		char* oursPath,
+		unsigned int oursMode,
+		char* theirsContents,
+		size_t theirsLen,
+		char* theirsPath,
+		unsigned int theirsMode,
+		git_merge_file_options* copts)
+{
 	git_merge_file_input ancestor = GIT_MERGE_FILE_INPUT_INIT;
 	git_merge_file_input ours = GIT_MERGE_FILE_INPUT_INIT;
 	git_merge_file_input theirs = GIT_MERGE_FILE_INPUT_INIT;
@@ -169,12 +407,14 @@ int _go_git_merge_file(git_merge_file_result* out, char* ancestorContents, size_
 	return git_merge_file(out, &ancestor, &ours, &theirs, copts);
 }
 
-void _go_git_setup_stash_apply_progress_callbacks(git_stash_apply_options *opts) {
-	opts->progress_cb = (git_stash_apply_progress_cb)stashApplyProgressCb;
+void _go_git_populate_stash_apply_callbacks(git_stash_apply_options *opts)
+{
+	opts->progress_cb = (git_stash_apply_progress_cb)&stashApplyProgressCallback;
 }
 
-int _go_git_stash_foreach(git_repository *repo, void *payload) {
-    return git_stash_foreach(repo, (git_stash_cb)&stashForeachCb, payload);
+int _go_git_stash_foreach(git_repository *repo, void *payload)
+{
+	return git_stash_foreach(repo, (git_stash_cb)&stashForeachCallback, payload);
 }
 
 int _go_git_writestream_write(git_writestream *stream, const char *buffer, size_t len)
@@ -192,16 +432,21 @@ void _go_git_writestream_free(git_writestream *stream)
 	stream->free(stream);
 }
 
-git_credential_t _go_git_credential_credtype(git_credential *cred) {
+git_credential_t _go_git_credential_credtype(git_credential *cred)
+{
 	return cred->credtype;
 }
 
 int _go_git_odb_write_pack(git_odb_writepack **out, git_odb *db, void *progress_payload)
 {
-	return git_odb_write_pack(out, db, (git_transfer_progress_cb)transferProgressCallback, progress_payload);
+	return git_odb_write_pack(out, db, transfer_progress_callback, progress_payload);
 }
 
-int _go_git_odb_writepack_append(git_odb_writepack *writepack, const void *data, size_t size, git_transfer_progress *stats)
+int _go_git_odb_writepack_append(
+		git_odb_writepack *writepack,
+		const void *data,
+		size_t size,
+		git_transfer_progress *stats)
 {
 	return writepack->append(writepack, data, size, stats);
 }
@@ -216,12 +461,15 @@ void _go_git_odb_writepack_free(git_odb_writepack *writepack)
 	writepack->free(writepack);
 }
 
-int _go_git_indexer_new(git_indexer **out, const char *path, unsigned int mode, git_odb *odb, void *progress_cb_payload)
+int _go_git_indexer_new(
+		git_indexer **out,
+		const char *path,
+		unsigned int mode,
+		git_odb *odb,
+		void *progress_cb_payload)
 {
 	git_indexer_options indexer_options = GIT_INDEXER_OPTIONS_INIT;
-	indexer_options.progress_cb = (git_transfer_progress_cb)transferProgressCallback;
+	indexer_options.progress_cb = transfer_progress_callback;
 	indexer_options.progress_cb_payload = progress_cb_payload;
 	return git_indexer_new(out, path, mode, odb, &indexer_options);
 }
-
-/* EOF */


### PR DESCRIPTION
This change is a preparation for another change that makes all callback
types return a Go error instead of an error code / an integer. That is
going to make make things a lot more idiomatic.

The reason this change is split is threefold:

a) This change is mostly mechanical and should contain no semantic
   changes.
b) This change is backwards-compatible (in the Go API compatibility
   sense of the word), and thus can be backported to all other releases.
c) It makes the other change a bit smaller and more focused on just one
   thing.

Concretely, this change makes all callbacks populate a Go error when
they fail. If the callback is invoked from the same stack as the
function to which it was passed (e.g. for `Tree.Walk`), it will preserve
the error object directly into a struct that also holds the callback
function. Otherwise if the callback is pased to one func and will be
invoked when run from another one (e.g. for `Repository.InitRebase`),
the error string is saved into the libgit2 thread-local storage and then
re-created as a `GitError`.