### PR TITLE
More callback refactoring

### DIFF
--- a/checkout.go
+++ b/checkout.go
@@ -87,13 +87,6 @@ func checkoutOptionsFromC(c *C.git_checkout_options) CheckoutOptions {
 	return opts
 }
 
-func (opts *CheckoutOptions) toC(errorTarget *error) *C.git_checkout_options {
-	if opts == nil {
-		return nil
-	}
-	return populateCheckoutOptions(&C.git_checkout_options{}, opts, errorTarget)
-}
-
 type checkoutCallbackData struct {
 	options     *CheckoutOptions
 	errorTarget *error
@@ -144,61 +137,61 @@ func checkoutProgressCallback(
 	data.options.ProgressCallback(C.GoString(path), uint(completed_steps), uint(total_steps))
 }
 
-// Convert the CheckoutOptions struct to the corresponding
-// C-struct. Returns a pointer to ptr, or nil if opts is nil, in order
-// to help with what to pass.
-func populateCheckoutOptions(ptr *C.git_checkout_options, opts *CheckoutOptions, errorTarget *error) *C.git_checkout_options {
+// populateCheckoutOptions populates the provided C-struct with the contents of
+// the provided CheckoutOptions struct.  Returns copts, or nil if opts is nil,
+// in order to help with what to pass.
+func populateCheckoutOptions(copts *C.git_checkout_options, opts *CheckoutOptions, errorTarget *error) *C.git_checkout_options {
+	C.git_checkout_options_init(copts, C.GIT_CHECKOUT_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
 
-	C.git_checkout_options_init(ptr, 1)
-	ptr.checkout_strategy = C.uint(opts.Strategy)
-	ptr.disable_filters = cbool(opts.DisableFilters)
-	ptr.dir_mode = C.uint(opts.DirMode.Perm())
-	ptr.file_mode = C.uint(opts.FileMode.Perm())
-	ptr.notify_flags = C.uint(opts.NotifyFlags)
+	copts.checkout_strategy = C.uint(opts.Strategy)
+	copts.disable_filters = cbool(opts.DisableFilters)
+	copts.dir_mode = C.uint(opts.DirMode.Perm())
+	copts.file_mode = C.uint(opts.FileMode.Perm())
+	copts.notify_flags = C.uint(opts.NotifyFlags)
 	if opts.NotifyCallback != nil || opts.ProgressCallback != nil {
-		C._go_git_populate_checkout_callbacks(ptr)
+		C._go_git_populate_checkout_callbacks(copts)
 		data := &checkoutCallbackData{
 			options:     opts,
 			errorTarget: errorTarget,
 		}
 		payload := pointerHandles.Track(data)
 		if opts.NotifyCallback != nil {
-			ptr.notify_payload = payload
+			copts.notify_payload = payload
 		}
 		if opts.ProgressCallback != nil {
-			ptr.progress_payload = payload
+			copts.progress_payload = payload
 		}
 	}
 	if opts.TargetDirectory != "" {
-		ptr.target_directory = C.CString(opts.TargetDirectory)
+		copts.target_directory = C.CString(opts.TargetDirectory)
 	}
 	if len(opts.Paths) > 0 {
-		ptr.paths.strings = makeCStringsFromStrings(opts.Paths)
-		ptr.paths.count = C.size_t(len(opts.Paths))
+		copts.paths.strings = makeCStringsFromStrings(opts.Paths)
+		copts.paths.count = C.size_t(len(opts.Paths))
 	}
 
 	if opts.Baseline != nil {
-		ptr.baseline = opts.Baseline.cast_ptr
+		copts.baseline = opts.Baseline.cast_ptr
 	}
 
-	return ptr
+	return copts
 }
 
-func freeCheckoutOptions(ptr *C.git_checkout_options) {
-	if ptr == nil {
+func freeCheckoutOptions(copts *C.git_checkout_options) {
+	if copts == nil {
 		return
 	}
-	C.free(unsafe.Pointer(ptr.target_directory))
-	if ptr.paths.count > 0 {
-		freeStrarray(&ptr.paths)
+	C.free(unsafe.Pointer(copts.target_directory))
+	if copts.paths.count > 0 {
+		freeStrarray(&copts.paths)
 	}
-	if ptr.notify_payload != nil {
-		pointerHandles.Untrack(ptr.notify_payload)
-	} else if ptr.progress_payload != nil {
-		pointerHandles.Untrack(ptr.progress_payload)
+	if copts.notify_payload != nil {
+		pointerHandles.Untrack(copts.notify_payload)
+	} else if copts.progress_payload != nil {
+		pointerHandles.Untrack(copts.progress_payload)
 	}
 }
 
@@ -209,7 +202,7 @@ func (v *Repository) CheckoutHead(opts *CheckoutOptions) error {
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_head(v.ptr, cOpts)
@@ -238,7 +231,7 @@ func (v *Repository) CheckoutIndex(index *Index, opts *CheckoutOptions) error {
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_index(v.ptr, iptr, cOpts)
@@ -258,7 +251,7 @@ func (v *Repository) CheckoutTree(tree *Tree, opts *CheckoutOptions) error {
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_tree(v.ptr, tree.ptr, cOpts)

--- a/cherrypick.go
+++ b/cherrypick.go
@@ -25,24 +25,23 @@ func cherrypickOptionsFromC(c *C.git_cherrypick_options) CherrypickOptions {
 	return opts
 }
 
-func (opts *CherrypickOptions) toC(errorTarget *error) *C.git_cherrypick_options {
+func populateCherrypickOptions(copts *C.git_cherrypick_options, opts *CherrypickOptions, errorTarget *error) *C.git_cherrypick_options {
+	C.git_cherrypick_options_init(copts, C.GIT_CHERRYPICK_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
-	c := C.git_cherrypick_options{}
-	c.version = C.uint(opts.Version)
-	c.mainline = C.uint(opts.Mainline)
-	c.merge_opts = *opts.MergeOpts.toC()
-	c.checkout_opts = *opts.CheckoutOpts.toC(errorTarget)
-	return &c
+	copts.mainline = C.uint(opts.Mainline)
+	populateMergeOptions(&copts.merge_opts, &opts.MergeOpts)
+	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOpts, errorTarget)
+	return copts
 }
 
-func freeCherrypickOpts(ptr *C.git_cherrypick_options) {
-	if ptr == nil {
+func freeCherrypickOpts(copts *C.git_cherrypick_options) {
+	if copts == nil {
 		return
 	}
-	freeMergeOptions(&ptr.merge_opts)
-	freeCheckoutOptions(&ptr.checkout_opts)
+	freeMergeOptions(&copts.merge_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
 }
 
 func DefaultCherrypickOptions() (CherrypickOptions, error) {
@@ -64,7 +63,7 @@ func (v *Repository) Cherrypick(commit *Commit, opts CherrypickOptions) error {
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCherrypickOptions(&C.git_cherrypick_options{}, &opts, &err)
 	defer freeCherrypickOpts(cOpts)
 
 	ret := C.git_cherrypick(v.ptr, commit.cast_ptr, cOpts)
@@ -83,7 +82,7 @@ func (r *Repository) CherrypickCommit(pick, our *Commit, opts CherrypickOptions)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cOpts := opts.MergeOpts.toC()
+	cOpts := populateMergeOptions(&C.git_merge_options{}, &opts.MergeOpts)
 	defer freeMergeOptions(cOpts)
 
 	var ptr *C.git_index

--- a/clone_test.go
+++ b/clone_test.go
@@ -74,4 +74,5 @@ func TestCloneWithCallback(t *testing.T) {
 	if err != nil || remote == nil {
 		t.Fatal("Remote was not created properly")
 	}
+	defer remote.Free()
 }

--- a/git_test.go
+++ b/git_test.go
@@ -1,12 +1,32 @@
 package git
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	ret := m.Run()
+
+	// Ensure that we are not leaking any pointer handles.
+	pointerHandles.Lock()
+	if len(pointerHandles.handles) > 0 {
+		for h, ptr := range pointerHandles.handles {
+			fmt.Printf("%016p: %v %+v\n", h, reflect.TypeOf(ptr), ptr)
+		}
+		panic("pointer handle list not empty")
+	}
+	pointerHandles.Unlock()
+
+	Shutdown()
+
+	os.Exit(ret)
+}
 
 func cleanupTestRepo(t *testing.T, r *Repository) {
 	var err error

--- a/merge.go
+++ b/merge.go
@@ -172,21 +172,20 @@ func DefaultMergeOptions() (MergeOptions, error) {
 	return mergeOptionsFromC(&opts), nil
 }
 
-func (mo *MergeOptions) toC() *C.git_merge_options {
-	if mo == nil {
+func populateMergeOptions(copts *C.git_merge_options, opts *MergeOptions) *C.git_merge_options {
+	C.git_merge_options_init(copts, C.GIT_MERGE_OPTIONS_VERSION)
+	if opts == nil {
 		return nil
 	}
-	return &C.git_merge_options{
-		version:          C.uint(mo.Version),
-		flags:            C.uint32_t(mo.TreeFlags),
-		rename_threshold: C.uint(mo.RenameThreshold),
-		target_limit:     C.uint(mo.TargetLimit),
-		recursion_limit:  C.uint(mo.RecursionLimit),
-		file_favor:       C.git_merge_file_favor_t(mo.FileFavor),
-	}
+	copts.flags = C.uint32_t(opts.TreeFlags)
+	copts.rename_threshold = C.uint(opts.RenameThreshold)
+	copts.target_limit = C.uint(opts.TargetLimit)
+	copts.recursion_limit = C.uint(opts.RecursionLimit)
+	copts.file_favor = C.git_merge_file_favor_t(opts.FileFavor)
+	return copts
 }
 
-func freeMergeOptions(opts *C.git_merge_options) {
+func freeMergeOptions(copts *C.git_merge_options) {
 }
 
 type MergeFileFavor int
@@ -203,9 +202,9 @@ func (r *Repository) Merge(theirHeads []*AnnotatedCommit, mergeOptions *MergeOpt
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cMergeOpts := mergeOptions.toC()
+	cMergeOpts := populateMergeOptions(&C.git_merge_options{}, mergeOptions)
 	defer freeMergeOptions(cMergeOpts)
-	cCheckoutOptions := checkoutOptions.toC(&err)
+	cCheckoutOptions := populateCheckoutOptions(&C.git_checkout_options{}, checkoutOptions, &err)
 	defer freeCheckoutOptions(cCheckoutOptions)
 
 	gmerge_head_array := make([]*C.git_annotated_commit, len(theirHeads))
@@ -269,7 +268,7 @@ func (r *Repository) MergeCommits(ours *Commit, theirs *Commit, options *MergeOp
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	copts := options.toC()
+	copts := populateMergeOptions(&C.git_merge_options{}, options)
 	defer freeMergeOptions(copts)
 
 	var ptr *C.git_index
@@ -287,7 +286,7 @@ func (r *Repository) MergeTrees(ancestor *Tree, ours *Tree, theirs *Tree, option
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	copts := options.toC()
+	copts := populateMergeOptions(&C.git_merge_options{}, options)
 	defer freeMergeOptions(copts)
 
 	var ancestor_ptr *C.git_tree
@@ -446,22 +445,28 @@ func mergeFileOptionsFromC(c C.git_merge_file_options) MergeFileOptions {
 	}
 }
 
-func populateCMergeFileOptions(c *C.git_merge_file_options, options MergeFileOptions) {
-	c.ancestor_label = C.CString(options.AncestorLabel)
-	c.our_label = C.CString(options.OurLabel)
-	c.their_label = C.CString(options.TheirLabel)
-	c.favor = C.git_merge_file_favor_t(options.Favor)
-	c.flags = C.uint32_t(options.Flags)
-	c.marker_size = C.ushort(options.MarkerSize)
+func populateMergeFileOptions(copts *C.git_merge_file_options, opts *MergeFileOptions) *C.git_merge_file_options {
+	C.git_merge_file_options_init(copts, C.GIT_MERGE_FILE_OPTIONS_VERSION)
+	if opts == nil {
+		return nil
+	}
+
+	copts.ancestor_label = C.CString(opts.AncestorLabel)
+	copts.our_label = C.CString(opts.OurLabel)
+	copts.their_label = C.CString(opts.TheirLabel)
+	copts.favor = C.git_merge_file_favor_t(opts.Favor)
+	copts.flags = C.uint32_t(opts.Flags)
+	copts.marker_size = C.ushort(opts.MarkerSize)
+	return copts
 }
 
-func freeCMergeFileOptions(c *C.git_merge_file_options) {
-	if c == nil {
+func freeMergeFileOptions(copts *C.git_merge_file_options) {
+	if copts == nil {
 		return
 	}
-	C.free(unsafe.Pointer(c.ancestor_label))
-	C.free(unsafe.Pointer(c.our_label))
-	C.free(unsafe.Pointer(c.their_label))
+	C.free(unsafe.Pointer(copts.ancestor_label))
+	C.free(unsafe.Pointer(copts.our_label))
+	C.free(unsafe.Pointer(copts.their_label))
 }
 
 func MergeFile(ancestor MergeFileInput, ours MergeFileInput, theirs MergeFileInput, options *MergeFileOptions) (*MergeFileResult, error) {
@@ -494,8 +499,8 @@ func MergeFile(ancestor MergeFileInput, ours MergeFileInput, theirs MergeFileInp
 		if ecode < 0 {
 			return nil, MakeGitError(ecode)
 		}
-		populateCMergeFileOptions(copts, *options)
-		defer freeCMergeFileOptions(copts)
+		populateMergeFileOptions(copts, options)
+		defer freeMergeFileOptions(copts)
 	}
 
 	runtime.LockOSThread()

--- a/object.go
+++ b/object.go
@@ -77,14 +77,14 @@ func (o *Object) Type() ObjectType {
 	return ret
 }
 
-// Owner returns a weak reference to the repository which owns this
-// object. This won't keep the underlying repository alive.
+// Owner returns a weak reference to the repository which owns this object.
+// This won't keep the underlying repository alive, but it should still be
+// Freed.
 func (o *Object) Owner() *Repository {
-	ret := &Repository{
-		ptr: C.git_object_owner(o.ptr),
-	}
+	repo := newRepositoryFromC(C.git_object_owner(o.ptr))
 	runtime.KeepAlive(o)
-	return ret
+	repo.weak = true
+	return repo
 }
 
 func dupObject(obj *Object, kind ObjectType) (*C.git_object, error) {

--- a/patch.go
+++ b/patch.go
@@ -78,7 +78,7 @@ func (v *Repository) PatchFromBuffers(oldPath, newPath string, oldBuf, newBuf []
 	defer C.free(unsafe.Pointer(cNewPath))
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()

--- a/push_test.go
+++ b/push_test.go
@@ -14,15 +14,18 @@ func TestRemotePush(t *testing.T) {
 
 	remote, err := localRepo.Remotes.Create("test_push", repo.Path())
 	checkFatal(t, err)
+	defer remote.Free()
 
 	seedTestRepo(t, localRepo)
 
 	err = remote.Push([]string{"refs/heads/master"}, nil)
 	checkFatal(t, err)
 
-	_, err = localRepo.References.Lookup("refs/remotes/test_push/master")
+	ref, err := localRepo.References.Lookup("refs/remotes/test_push/master")
 	checkFatal(t, err)
+	defer ref.Free()
 
-	_, err = repo.References.Lookup("refs/heads/master")
+	ref, err = repo.References.Lookup("refs/heads/master")
 	checkFatal(t, err)
+	defer ref.Free()
 }

--- a/reference.go
+++ b/reference.go
@@ -293,12 +293,14 @@ func (v *Reference) Peel(t ObjectType) (*Object, error) {
 	return allocObject(cobj, v.repo), nil
 }
 
-// Owner returns a weak reference to the repository which owns this
-// reference.
+// Owner returns a weak reference to the repository which owns this reference.
+// This won't keep the underlying repository alive, but it should still be
+// Freed.
 func (v *Reference) Owner() *Repository {
-	return &Repository{
-		ptr: C.git_reference_owner(v.ptr),
-	}
+	repo := newRepositoryFromC(C.git_reference_owner(v.ptr))
+	runtime.KeepAlive(v)
+	repo.weak = true
+	return repo
 }
 
 // Cmp compares v to ref2. It returns 0 on equality, otherwise a

--- a/remote.go
+++ b/remote.go
@@ -435,10 +435,12 @@ func RemoteIsValidName(name string) bool {
 	return C.git_remote_is_valid_name(cname) == 1
 }
 
+// Free releases the resources of the Remote.
 func (r *Remote) Free() {
 	runtime.SetFinalizer(r, nil)
 	C.git_remote_free(r.ptr)
 	r.ptr = nil
+	r.repo = nil
 }
 
 type RemoteCollection struct {

--- a/remote.go
+++ b/remote.go
@@ -7,7 +7,6 @@ package git
 #include <git2/sys/cred.h>
 
 extern void _go_git_populate_remote_callbacks(git_remote_callbacks *callbacks);
-
 */
 import "C"
 import (
@@ -72,6 +71,11 @@ type RemoteCallbacks struct {
 	PushUpdateReferenceCallback
 }
 
+type remoteCallbacksData struct {
+	callbacks   *RemoteCallbacks
+	errorTarget *error
+}
+
 type FetchPrune uint
 
 const (
@@ -86,7 +90,6 @@ const (
 type DownloadTags uint
 
 const (
-
 	// Use the setting from the configuration.
 	DownloadTagsUnspecified DownloadTags = C.GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED
 	// Ask the server for tags pointing to objects we're already
@@ -209,44 +212,58 @@ func newRemoteHeadFromC(ptr *C.git_remote_head) RemoteHead {
 	}
 }
 
-func untrackCalbacksPayload(callbacks *C.git_remote_callbacks) {
-	if callbacks != nil && callbacks.payload != nil {
-		pointerHandles.Untrack(callbacks.payload)
-	}
-}
-
-func populateRemoteCallbacks(ptr *C.git_remote_callbacks, callbacks *RemoteCallbacks) {
-	C.git_remote_init_callbacks(ptr, C.GIT_REMOTE_CALLBACKS_VERSION)
-	if callbacks == nil {
+func untrackCallbacksPayload(callbacks *C.git_remote_callbacks) {
+	if callbacks == nil || callbacks.payload == nil {
 		return
 	}
+	pointerHandles.Untrack(callbacks.payload)
+}
+
+func populateRemoteCallbacks(ptr *C.git_remote_callbacks, callbacks *RemoteCallbacks, errorTarget *error) *C.git_remote_callbacks {
+	C.git_remote_init_callbacks(ptr, C.GIT_REMOTE_CALLBACKS_VERSION)
+	if callbacks == nil {
+		return ptr
+	}
 	C._go_git_populate_remote_callbacks(ptr)
-	ptr.payload = pointerHandles.Track(callbacks)
+	data := &remoteCallbacksData{
+		callbacks:   callbacks,
+		errorTarget: errorTarget,
+	}
+	ptr.payload = pointerHandles.Track(data)
+	return ptr
 }
 
 //export sidebandProgressCallback
-func sidebandProgressCallback(errorMessage **C.char, _str *C.char, _len C.int, data unsafe.Pointer) C.int {
-	callbacks := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.SidebandProgressCallback == nil {
+func sidebandProgressCallback(errorMessage **C.char, _str *C.char, _len C.int, handle unsafe.Pointer) C.int {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.SidebandProgressCallback == nil {
 		return C.int(ErrorCodeOK)
 	}
 	str := C.GoStringN(_str, _len)
-	ret := callbacks.SidebandProgressCallback(str)
+	ret := data.callbacks.SidebandProgressCallback(str)
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
 
 //export completionCallback
-func completionCallback(errorMessage **C.char, completion_type C.git_remote_completion_type, data unsafe.Pointer) C.int {
-	callbacks := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.CompletionCallback == nil {
+func completionCallback(errorMessage **C.char, completion_type C.git_remote_completion_type, handle unsafe.Pointer) C.int {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.CompletionCallback == nil {
 		return C.int(ErrorCodeOK)
 	}
-	ret := callbacks.CompletionCallback(RemoteCompletion(completion_type))
+	ret := data.callbacks.CompletionCallback(RemoteCompletion(completion_type))
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
@@ -258,16 +275,19 @@ func credentialsCallback(
 	_url *C.char,
 	_username_from_url *C.char,
 	allowed_types uint,
-	data unsafe.Pointer,
+	handle unsafe.Pointer,
 ) C.int {
-	callbacks, _ := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.CredentialsCallback == nil {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.CredentialsCallback == nil {
 		return C.int(ErrorCodePassthrough)
 	}
 	url := C.GoString(_url)
 	username_from_url := C.GoString(_username_from_url)
-	cred, err := callbacks.CredentialsCallback(url, username_from_url, (CredentialType)(allowed_types))
+	cred, err := data.callbacks.CredentialsCallback(url, username_from_url, (CredentialType)(allowed_types))
 	if err != nil {
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
 		return setCallbackError(errorMessage, err)
 	}
 	if cred != nil {
@@ -281,14 +301,18 @@ func credentialsCallback(
 }
 
 //export transferProgressCallback
-func transferProgressCallback(errorMessage **C.char, stats *C.git_transfer_progress, data unsafe.Pointer) C.int {
-	callbacks, _ := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.TransferProgressCallback == nil {
+func transferProgressCallback(errorMessage **C.char, stats *C.git_transfer_progress, handle unsafe.Pointer) C.int {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.TransferProgressCallback == nil {
 		return C.int(ErrorCodeOK)
 	}
-	ret := callbacks.TransferProgressCallback(newTransferProgressFromC(stats))
+	ret := data.callbacks.TransferProgressCallback(newTransferProgressFromC(stats))
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
@@ -299,18 +323,22 @@ func updateTipsCallback(
 	_refname *C.char,
 	_a *C.git_oid,
 	_b *C.git_oid,
-	data unsafe.Pointer,
+	handle unsafe.Pointer,
 ) C.int {
-	callbacks, _ := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.UpdateTipsCallback == nil {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.UpdateTipsCallback == nil {
 		return C.int(ErrorCodeOK)
 	}
 	refname := C.GoString(_refname)
 	a := newOidFromC(_a)
 	b := newOidFromC(_b)
-	ret := callbacks.UpdateTipsCallback(refname, a, b)
+	ret := data.callbacks.UpdateTipsCallback(refname, a, b)
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
@@ -321,11 +349,11 @@ func certificateCheckCallback(
 	_cert *C.git_cert,
 	_valid C.int,
 	_host *C.char,
-	data unsafe.Pointer,
+	handle unsafe.Pointer,
 ) C.int {
-	callbacks, _ := pointerHandles.Get(data).(*RemoteCallbacks)
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
 	// if there's no callback set, we need to make sure we fail if the library didn't consider this cert valid
-	if callbacks.CertificateCheckCallback == nil {
+	if data.callbacks.CertificateCheckCallback == nil {
 		if _valid == 0 {
 			return C.int(ErrorCodeCertificate)
 		}
@@ -341,10 +369,17 @@ func certificateCheckCallback(
 		ccert := (*C.git_cert_x509)(unsafe.Pointer(_cert))
 		x509_certs, err := x509.ParseCertificates(C.GoBytes(ccert.data, C.int(ccert.len)))
 		if err != nil {
+			if data.errorTarget != nil {
+				*data.errorTarget = err
+			}
 			return setCallbackError(errorMessage, err)
 		}
 		if len(x509_certs) < 1 {
-			return setCallbackError(errorMessage, errors.New("empty certificate list"))
+			err := errors.New("empty certificate list")
+			if data.errorTarget != nil {
+				*data.errorTarget = err
+			}
+			return setCallbackError(errorMessage, err)
 		}
 
 		// we assume there's only one, which should hold true for any web server we want to talk to
@@ -357,74 +392,95 @@ func certificateCheckCallback(
 		C.memcpy(unsafe.Pointer(&cert.Hostkey.HashSHA1[0]), unsafe.Pointer(&ccert.hash_sha1[0]), C.size_t(len(cert.Hostkey.HashSHA1)))
 		C.memcpy(unsafe.Pointer(&cert.Hostkey.HashSHA256[0]), unsafe.Pointer(&ccert.hash_sha256[0]), C.size_t(len(cert.Hostkey.HashSHA256)))
 	} else {
-		return setCallbackError(errorMessage, errors.New("unsupported certificate type"))
+		err := errors.New("unsupported certificate type")
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 
-	ret := callbacks.CertificateCheckCallback(&cert, valid, host)
+	ret := data.callbacks.CertificateCheckCallback(&cert, valid, host)
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
 
 //export packProgressCallback
-func packProgressCallback(errorMessage **C.char, stage C.int, current, total C.uint, data unsafe.Pointer) C.int {
-	callbacks, _ := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.PackProgressCallback == nil {
+func packProgressCallback(errorMessage **C.char, stage C.int, current, total C.uint, handle unsafe.Pointer) C.int {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.PackProgressCallback == nil {
 		return C.int(ErrorCodeOK)
 	}
 
-	ret := callbacks.PackProgressCallback(int32(stage), uint32(current), uint32(total))
+	ret := data.callbacks.PackProgressCallback(int32(stage), uint32(current), uint32(total))
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
 
 //export pushTransferProgressCallback
-func pushTransferProgressCallback(errorMessage **C.char, current, total C.uint, bytes C.size_t, data unsafe.Pointer) C.int {
-	callbacks, _ := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.PushTransferProgressCallback == nil {
+func pushTransferProgressCallback(errorMessage **C.char, current, total C.uint, bytes C.size_t, handle unsafe.Pointer) C.int {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.PushTransferProgressCallback == nil {
 		return C.int(ErrorCodeOK)
 	}
 
-	ret := callbacks.PushTransferProgressCallback(uint32(current), uint32(total), uint(bytes))
+	ret := data.callbacks.PushTransferProgressCallback(uint32(current), uint32(total), uint(bytes))
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
 
 //export pushUpdateReferenceCallback
-func pushUpdateReferenceCallback(errorMessage **C.char, refname, status *C.char, data unsafe.Pointer) C.int {
-	callbacks, _ := pointerHandles.Get(data).(*RemoteCallbacks)
-	if callbacks.PushUpdateReferenceCallback == nil {
+func pushUpdateReferenceCallback(errorMessage **C.char, refname, status *C.char, handle unsafe.Pointer) C.int {
+	data := pointerHandles.Get(handle).(*remoteCallbacksData)
+	if data.callbacks.PushUpdateReferenceCallback == nil {
 		return C.int(ErrorCodeOK)
 	}
 
-	ret := callbacks.PushUpdateReferenceCallback(C.GoString(refname), C.GoString(status))
+	ret := data.callbacks.PushUpdateReferenceCallback(C.GoString(refname), C.GoString(status))
 	if ret < 0 {
-		return setCallbackError(errorMessage, errors.New(ErrorCode(ret).String()))
+		err := errors.New(ErrorCode(ret).String())
+		if data.errorTarget != nil {
+			*data.errorTarget = err
+		}
+		return setCallbackError(errorMessage, err)
 	}
 	return C.int(ErrorCodeOK)
 }
 
-func populateProxyOptions(ptr *C.git_proxy_options, opts *ProxyOptions) {
-	C.git_proxy_options_init(ptr, C.GIT_PROXY_OPTIONS_VERSION)
+func populateProxyOptions(copts *C.git_proxy_options, opts *ProxyOptions) *C.git_proxy_options {
+	C.git_proxy_options_init(copts, C.GIT_PROXY_OPTIONS_VERSION)
 	if opts == nil {
-		return
+		return nil
 	}
 
-	ptr._type = C.git_proxy_t(opts.Type)
-	ptr.url = C.CString(opts.Url)
+	copts._type = C.git_proxy_t(opts.Type)
+	copts.url = C.CString(opts.Url)
+	return copts
 }
 
-func freeProxyOptions(ptr *C.git_proxy_options) {
-	if ptr == nil {
+func freeProxyOptions(copts *C.git_proxy_options) {
+	if copts == nil {
 		return
 	}
 
-	C.free(unsafe.Pointer(ptr.url))
+	C.free(unsafe.Pointer(copts.url))
 }
 
 // RemoteIsValidName returns whether the remote name is well-formed.
@@ -738,35 +794,54 @@ func (o *Remote) RefspecCount() uint {
 	return uint(count)
 }
 
-func populateFetchOptions(options *C.git_fetch_options, opts *FetchOptions) {
-	C.git_fetch_options_init(options, C.GIT_FETCH_OPTIONS_VERSION)
+func populateFetchOptions(copts *C.git_fetch_options, opts *FetchOptions, errorTarget *error) *C.git_fetch_options {
+	C.git_fetch_options_init(copts, C.GIT_FETCH_OPTIONS_VERSION)
 	if opts == nil {
-		return
+		return nil
 	}
-	populateRemoteCallbacks(&options.callbacks, &opts.RemoteCallbacks)
-	options.prune = C.git_fetch_prune_t(opts.Prune)
-	options.update_fetchhead = cbool(opts.UpdateFetchhead)
-	options.download_tags = C.git_remote_autotag_option_t(opts.DownloadTags)
+	populateRemoteCallbacks(&copts.callbacks, &opts.RemoteCallbacks, errorTarget)
+	copts.prune = C.git_fetch_prune_t(opts.Prune)
+	copts.update_fetchhead = cbool(opts.UpdateFetchhead)
+	copts.download_tags = C.git_remote_autotag_option_t(opts.DownloadTags)
 
-	options.custom_headers = C.git_strarray{}
-	options.custom_headers.count = C.size_t(len(opts.Headers))
-	options.custom_headers.strings = makeCStringsFromStrings(opts.Headers)
-	populateProxyOptions(&options.proxy_opts, &opts.ProxyOptions)
+	copts.custom_headers = C.git_strarray{
+		count:   C.size_t(len(opts.Headers)),
+		strings: makeCStringsFromStrings(opts.Headers),
+	}
+	populateProxyOptions(&copts.proxy_opts, &opts.ProxyOptions)
+	return copts
 }
 
-func populatePushOptions(options *C.git_push_options, opts *PushOptions) {
-	C.git_push_options_init(options, C.GIT_PUSH_OPTIONS_VERSION)
-	if opts == nil {
+func freeFetchOptions(copts *C.git_fetch_options) {
+	if copts == nil {
 		return
 	}
+	freeStrarray(&copts.custom_headers)
+	untrackCallbacksPayload(&copts.callbacks)
+	freeProxyOptions(&copts.proxy_opts)
+}
 
-	options.pb_parallelism = C.uint(opts.PbParallelism)
+func populatePushOptions(copts *C.git_push_options, opts *PushOptions, errorTarget *error) *C.git_push_options {
+	C.git_push_options_init(copts, C.GIT_PUSH_OPTIONS_VERSION)
+	if opts == nil {
+		return nil
+	}
 
-	options.custom_headers = C.git_strarray{}
-	options.custom_headers.count = C.size_t(len(opts.Headers))
-	options.custom_headers.strings = makeCStringsFromStrings(opts.Headers)
+	copts.pb_parallelism = C.uint(opts.PbParallelism)
+	copts.custom_headers = C.git_strarray{
+		count:   C.size_t(len(opts.Headers)),
+		strings: makeCStringsFromStrings(opts.Headers),
+	}
+	populateRemoteCallbacks(&copts.callbacks, &opts.RemoteCallbacks, errorTarget)
+	return copts
+}
 
-	populateRemoteCallbacks(&options.callbacks, &opts.RemoteCallbacks)
+func freePushOptions(copts *C.git_push_options) {
+	if copts == nil {
+		return
+	}
+	untrackCallbacksPayload(&copts.callbacks)
+	freeStrarray(&copts.custom_headers)
 }
 
 // Fetch performs a fetch operation. refspecs specifies which refspecs
@@ -780,26 +855,29 @@ func (o *Remote) Fetch(refspecs []string, opts *FetchOptions, msg string) error 
 		defer C.free(unsafe.Pointer(cmsg))
 	}
 
-	crefspecs := C.git_strarray{}
-	crefspecs.count = C.size_t(len(refspecs))
-	crefspecs.strings = makeCStringsFromStrings(refspecs)
+	var err error
+	crefspecs := C.git_strarray{
+		count:   C.size_t(len(refspecs)),
+		strings: makeCStringsFromStrings(refspecs),
+	}
 	defer freeStrarray(&crefspecs)
 
-	coptions := (*C.git_fetch_options)(C.calloc(1, C.size_t(unsafe.Sizeof(C.git_fetch_options{}))))
-	defer C.free(unsafe.Pointer(coptions))
-
-	populateFetchOptions(coptions, opts)
-	defer untrackCalbacksPayload(&coptions.callbacks)
-	defer freeStrarray(&coptions.custom_headers)
+	coptions := populateFetchOptions(&C.git_fetch_options{}, opts, &err)
+	defer freeFetchOptions(coptions)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_remote_fetch(o.ptr, &crefspecs, coptions, cmsg)
 	runtime.KeepAlive(o)
+
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
+	}
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
+
 	return nil
 }
 
@@ -819,23 +897,27 @@ func (o *Remote) ConnectPush(callbacks *RemoteCallbacks, proxyOpts *ProxyOptions
 //
 // 'headers' are extra HTTP headers to use in this connection.
 func (o *Remote) Connect(direction ConnectDirection, callbacks *RemoteCallbacks, proxyOpts *ProxyOptions, headers []string) error {
-	var ccallbacks C.git_remote_callbacks
-	populateRemoteCallbacks(&ccallbacks, callbacks)
+	var err error
+	ccallbacks := populateRemoteCallbacks(&C.git_remote_callbacks{}, callbacks, &err)
+	defer untrackCallbacksPayload(ccallbacks)
 
-	var cproxy C.git_proxy_options
-	populateProxyOptions(&cproxy, proxyOpts)
-	defer freeProxyOptions(&cproxy)
+	cproxy := populateProxyOptions(&C.git_proxy_options{}, proxyOpts)
+	defer freeProxyOptions(cproxy)
 
-	cheaders := C.git_strarray{}
-	cheaders.count = C.size_t(len(headers))
-	cheaders.strings = makeCStringsFromStrings(headers)
+	cheaders := C.git_strarray{
+		count:   C.size_t(len(headers)),
+		strings: makeCStringsFromStrings(headers),
+	}
 	defer freeStrarray(&cheaders)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_remote_connect(o.ptr, C.git_direction(direction), &ccallbacks, &cproxy, &cheaders)
+	ret := C.git_remote_connect(o.ptr, C.git_direction(direction), ccallbacks, cproxy, &cheaders)
 	runtime.KeepAlive(o)
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
+	}
 	if ret != 0 {
 		return MakeGitError(ret)
 	}
@@ -899,23 +981,24 @@ func (o *Remote) Ls(filterRefs ...string) ([]RemoteHead, error) {
 }
 
 func (o *Remote) Push(refspecs []string, opts *PushOptions) error {
-	crefspecs := C.git_strarray{}
-	crefspecs.count = C.size_t(len(refspecs))
-	crefspecs.strings = makeCStringsFromStrings(refspecs)
+	crefspecs := C.git_strarray{
+		count:   C.size_t(len(refspecs)),
+		strings: makeCStringsFromStrings(refspecs),
+	}
 	defer freeStrarray(&crefspecs)
 
-	coptions := (*C.git_push_options)(C.calloc(1, C.size_t(unsafe.Sizeof(C.git_push_options{}))))
-	defer C.free(unsafe.Pointer(coptions))
-
-	populatePushOptions(coptions, opts)
-	defer untrackCalbacksPayload(&coptions.callbacks)
-	defer freeStrarray(&coptions.custom_headers)
+	var err error
+	coptions := populatePushOptions(&C.git_push_options{}, opts, &err)
+	defer freePushOptions(coptions)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	ret := C.git_remote_push(o.ptr, &crefspecs, coptions)
 	runtime.KeepAlive(o)
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
+	}
 	if ret < 0 {
 		return MakeGitError(ret)
 	}
@@ -927,14 +1010,18 @@ func (o *Remote) PruneRefs() bool {
 }
 
 func (o *Remote) Prune(callbacks *RemoteCallbacks) error {
-	var ccallbacks C.git_remote_callbacks
-	populateRemoteCallbacks(&ccallbacks, callbacks)
+	var err error
+	ccallbacks := populateRemoteCallbacks(&C.git_remote_callbacks{}, callbacks, &err)
+	defer untrackCallbacksPayload(ccallbacks)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ret := C.git_remote_prune(o.ptr, &ccallbacks)
+	ret := C.git_remote_prune(o.ptr, ccallbacks)
 	runtime.KeepAlive(o)
+	if ret == C.int(ErrorCodeUser) && err != nil {
+		return err
+	}
 	if ret < 0 {
 		return MakeGitError(ret)
 	}

--- a/reset.go
+++ b/reset.go
@@ -19,7 +19,7 @@ func (r *Repository) ResetToCommit(commit *Commit, resetType ResetType, opts *Ch
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_reset(r.ptr, commit.ptr, C.git_reset_t(resetType), cOpts)

--- a/stash.go
+++ b/stash.go
@@ -161,34 +161,32 @@ func DefaultStashApplyOptions() (StashApplyOptions, error) {
 	}, nil
 }
 
-func (opts *StashApplyOptions) toC(errorTarget *error) *C.git_stash_apply_options {
+func populateStashApplyOptions(copts *C.git_stash_apply_options, opts *StashApplyOptions, errorTarget *error) *C.git_stash_apply_options {
+	C.git_stash_apply_options_init(copts, C.GIT_STASH_APPLY_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
-	optsC := &C.git_stash_apply_options{
-		version: C.GIT_STASH_APPLY_OPTIONS_VERSION,
-		flags:   C.uint32_t(opts.Flags),
-	}
-	populateCheckoutOptions(&optsC.checkout_options, &opts.CheckoutOptions, errorTarget)
+	copts.flags = C.uint32_t(opts.Flags)
+	populateCheckoutOptions(&copts.checkout_options, &opts.CheckoutOptions, errorTarget)
 	if opts.ProgressCallback != nil {
 		progressData := &stashApplyProgressCallbackData{
 			callback:    opts.ProgressCallback,
 			errorTarget: errorTarget,
 		}
-		C._go_git_populate_stash_apply_callbacks(optsC)
-		optsC.progress_payload = pointerHandles.Track(progressData)
+		C._go_git_populate_stash_apply_callbacks(copts)
+		copts.progress_payload = pointerHandles.Track(progressData)
 	}
-	return optsC
+	return copts
 }
 
-func freeStashApplyOptions(optsC *C.git_stash_apply_options) {
-	if optsC == nil {
+func freeStashApplyOptions(copts *C.git_stash_apply_options) {
+	if copts == nil {
 		return
 	}
-	if optsC.progress_payload != nil {
-		pointerHandles.Untrack(optsC.progress_payload)
+	if copts.progress_payload != nil {
+		pointerHandles.Untrack(copts.progress_payload)
 	}
-	freeCheckoutOptions(&optsC.checkout_options)
+	freeCheckoutOptions(&copts.checkout_options)
 }
 
 // Apply applies a single stashed state from the stash list.
@@ -217,7 +215,7 @@ func freeStashApplyOptions(optsC *C.git_stash_apply_options) {
 // Error codes can be interogated with IsErrorCode(err, ErrorCodeNotFound).
 func (c *StashCollection) Apply(index int, opts StashApplyOptions) error {
 	var err error
-	optsC := opts.toC(&err)
+	optsC := populateStashApplyOptions(&C.git_stash_apply_options{}, &opts, &err)
 	defer freeStashApplyOptions(optsC)
 
 	runtime.LockOSThread()
@@ -320,7 +318,7 @@ func (c *StashCollection) Drop(index int) error {
 // state for the given index.
 func (c *StashCollection) Pop(index int, opts StashApplyOptions) error {
 	var err error
-	optsC := opts.toC(&err)
+	optsC := populateStashApplyOptions(&C.git_stash_apply_options{}, &opts, &err)
 	defer freeStashApplyOptions(optsC)
 
 	runtime.LockOSThread()

--- a/submodule.go
+++ b/submodule.go
@@ -383,22 +383,22 @@ func (sub *Submodule) Update(init bool, opts *SubmoduleUpdateOptions) error {
 	return nil
 }
 
-func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *SubmoduleUpdateOptions, errorTarget *error) *C.git_submodule_update_options {
-	C.git_submodule_update_options_init(ptr, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
-
+func populateSubmoduleUpdateOptions(copts *C.git_submodule_update_options, opts *SubmoduleUpdateOptions, errorTarget *error) *C.git_submodule_update_options {
+	C.git_submodule_update_options_init(copts, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
 
-	populateCheckoutOptions(&ptr.checkout_opts, opts.CheckoutOpts, errorTarget)
-	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
+	populateCheckoutOptions(&copts.checkout_opts, opts.CheckoutOpts, errorTarget)
+	populateFetchOptions(&copts.fetch_opts, opts.FetchOptions, errorTarget)
 
-	return ptr
+	return copts
 }
 
-func freeSubmoduleUpdateOptions(ptr *C.git_submodule_update_options) {
-	if ptr == nil {
+func freeSubmoduleUpdateOptions(copts *C.git_submodule_update_options) {
+	if copts == nil {
 		return
 	}
-	freeCheckoutOptions(&ptr.checkout_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
+	freeFetchOptions(&copts.fetch_opts)
 }


### PR DESCRIPTION
This change:

* Gets rid of the `.toC()` functions for Options objects, since they
  were redundant with the `populateXxxOptions()`.
* Adds support for `errorTarget` to the `RemoteOptions`, since they are
  used in the same stack for some functions (like `Fetch()`). Now for
  those cases, the error returned by the callback will be preserved
  as-is.