### PR TITLE
More callback refactoring (#713)

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -94,15 +94,14 @@ type cloneCallbackData struct {
 	errorTarget *error
 }
 
-func populateCloneOptions(ptr *C.git_clone_options, opts *CloneOptions, errorTarget *error) *C.git_clone_options {
-	C.git_clone_init_options(ptr, C.GIT_CLONE_OPTIONS_VERSION)
-
+func populateCloneOptions(copts *C.git_clone_options, opts *CloneOptions, errorTarget *error) *C.git_clone_options {
+	C.git_clone_init_options(copts, C.GIT_CLONE_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
-	populateCheckoutOptions(&ptr.checkout_opts, opts.CheckoutOpts, errorTarget)
-	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
-	ptr.bare = cbool(opts.Bare)
+	populateCheckoutOptions(&copts.checkout_opts, opts.CheckoutOpts, errorTarget)
+	populateFetchOptions(&copts.fetch_opts, opts.FetchOptions, errorTarget)
+	copts.bare = cbool(opts.Bare)
 
 	if opts.RemoteCreateCallback != nil {
 		data := &cloneCallbackData{
@@ -110,23 +109,24 @@ func populateCloneOptions(ptr *C.git_clone_options, opts *CloneOptions, errorTar
 			errorTarget: errorTarget,
 		}
 		// Go v1.1 does not allow to assign a C function pointer
-		C._go_git_populate_clone_callbacks(ptr)
-		ptr.remote_cb_payload = pointerHandles.Track(data)
+		C._go_git_populate_clone_callbacks(copts)
+		copts.remote_cb_payload = pointerHandles.Track(data)
 	}
 
-	return ptr
+	return copts
 }
 
-func freeCloneOptions(ptr *C.git_clone_options) {
-	if ptr == nil {
+func freeCloneOptions(copts *C.git_clone_options) {
+	if copts == nil {
 		return
 	}
 
-	freeCheckoutOptions(&ptr.checkout_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
+	freeFetchOptions(&copts.fetch_opts)
 
-	if ptr.remote_cb_payload != nil {
-		pointerHandles.Untrack(ptr.remote_cb_payload)
+	if copts.remote_cb_payload != nil {
+		pointerHandles.Untrack(copts.remote_cb_payload)
 	}
 
-	C.free(unsafe.Pointer(ptr.checkout_branch))
+	C.free(unsafe.Pointer(copts.checkout_branch))
 }

--- a/diff.go
+++ b/diff.go
@@ -641,29 +641,24 @@ func diffNotifyCallback(_diff_so_far unsafe.Pointer, delta_to_add *C.git_diff_de
 	return C.int(ErrorCodeOK)
 }
 
-func (opts *DiffOptions) toC(repo *Repository, errorTarget *error) *C.git_diff_options {
+func populateDiffOptions(copts *C.git_diff_options, opts *DiffOptions, repo *Repository, errorTarget *error) *C.git_diff_options {
+	C.git_diff_init_options(copts, C.GIT_DIFF_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
 
-	cpathspec := C.git_strarray{}
-	if opts.Pathspec != nil {
-		cpathspec.count = C.size_t(len(opts.Pathspec))
-		cpathspec.strings = makeCStringsFromStrings(opts.Pathspec)
+	copts.flags = C.uint32_t(opts.Flags)
+	copts.ignore_submodules = C.git_submodule_ignore_t(opts.IgnoreSubmodules)
+	if len(opts.Pathspec) > 0 {
+		copts.pathspec.count = C.size_t(len(opts.Pathspec))
+		copts.pathspec.strings = makeCStringsFromStrings(opts.Pathspec)
 	}
-
-	copts := &C.git_diff_options{
-		version:           C.GIT_DIFF_OPTIONS_VERSION,
-		flags:             C.uint32_t(opts.Flags),
-		ignore_submodules: C.git_submodule_ignore_t(opts.IgnoreSubmodules),
-		pathspec:          cpathspec,
-		context_lines:     C.uint32_t(opts.ContextLines),
-		interhunk_lines:   C.uint32_t(opts.InterhunkLines),
-		id_abbrev:         C.uint16_t(opts.IdAbbrev),
-		max_size:          C.git_off_t(opts.MaxSize),
-		old_prefix:        C.CString(opts.OldPrefix),
-		new_prefix:        C.CString(opts.NewPrefix),
-	}
+	copts.context_lines = C.uint32_t(opts.ContextLines)
+	copts.interhunk_lines = C.uint32_t(opts.InterhunkLines)
+	copts.id_abbrev = C.uint16_t(opts.IdAbbrev)
+	copts.max_size = C.git_off_t(opts.MaxSize)
+	copts.old_prefix = C.CString(opts.OldPrefix)
+	copts.new_prefix = C.CString(opts.NewPrefix)
 
 	if opts.NotifyCallback != nil {
 		notifyData := &diffNotifyCallbackData{
@@ -681,8 +676,7 @@ func freeDiffOptions(copts *C.git_diff_options) {
 	if copts == nil {
 		return
 	}
-	cpathspec := copts.pathspec
-	freeStrarray(&cpathspec)
+	freeStrarray(&copts.pathspec)
 	C.free(unsafe.Pointer(copts.old_prefix))
 	C.free(unsafe.Pointer(copts.new_prefix))
 	if copts.payload != nil {
@@ -703,7 +697,7 @@ func (v *Repository) DiffTreeToTree(oldTree, newTree *Tree, opts *DiffOptions) (
 	}
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()
@@ -730,7 +724,7 @@ func (v *Repository) DiffTreeToWorkdir(oldTree *Tree, opts *DiffOptions) (*Diff,
 	}
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()
@@ -762,7 +756,7 @@ func (v *Repository) DiffTreeToIndex(oldTree *Tree, index *Index, opts *DiffOpti
 	}
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()
@@ -790,7 +784,7 @@ func (v *Repository) DiffTreeToWorkdirWithIndex(oldTree *Tree, opts *DiffOptions
 	}
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()
@@ -817,7 +811,7 @@ func (v *Repository) DiffIndexToWorkdir(index *Index, opts *DiffOptions) (*Diff,
 	}
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()
@@ -873,7 +867,7 @@ func DiffBlobs(oldBlob *Blob, oldAsPath string, newBlob *Blob, newAsPath string,
 	newBlobPath := C.CString(newAsPath)
 	defer C.free(unsafe.Pointer(newBlobPath))
 
-	copts := opts.toC(repo, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, repo, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()
@@ -970,37 +964,36 @@ func DefaultApplyOptions() (*ApplyOptions, error) {
 	return applyOptionsFromC(&opts), nil
 }
 
-func (a *ApplyOptions) toC(errorTarget *error) *C.git_apply_options {
-	if a == nil {
+func populateApplyOptions(copts *C.git_apply_options, opts *ApplyOptions, errorTarget *error) *C.git_apply_options {
+	*copts = C.git_apply_options{
+		version: C.GIT_APPLY_OPTIONS_VERSION,
+	}
+	if opts == nil {
 		return nil
 	}
 
-	opts := &C.git_apply_options{
-		version: C.GIT_APPLY_OPTIONS_VERSION,
-	}
-
-	if a.ApplyDeltaCallback != nil || a.ApplyHunkCallback != nil {
+	if opts.ApplyDeltaCallback != nil || opts.ApplyHunkCallback != nil {
 		data := &applyCallbackData{
-			options:     a,
+			options:     opts,
 			errorTarget: errorTarget,
 		}
-		C._go_git_populate_apply_callbacks(opts)
-		opts.payload = pointerHandles.Track(data)
+		C._go_git_populate_apply_callbacks(copts)
+		copts.payload = pointerHandles.Track(data)
 	}
 
-	return opts
+	return copts
 }
 
-func freeApplyOptions(opts *C.git_apply_options) {
-	if opts == nil {
+func freeApplyOptions(copts *C.git_apply_options) {
+	if copts == nil {
 		return
 	}
-	if opts.payload != nil {
-		pointerHandles.Untrack(opts.payload)
+	if copts.payload != nil {
+		pointerHandles.Untrack(copts.payload)
 	}
 }
 
-func applyOptionsFromC(opts *C.git_apply_options) *ApplyOptions {
+func applyOptionsFromC(copts *C.git_apply_options) *ApplyOptions {
 	return &ApplyOptions{}
 }
 
@@ -1028,7 +1021,7 @@ func (v *Repository) ApplyDiff(diff *Diff, location ApplyLocation, opts *ApplyOp
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateApplyOptions(&C.git_apply_options{}, opts, &err)
 	defer freeApplyOptions(cOpts)
 
 	ret := C.git_apply(v.ptr, diff.ptr, C.git_apply_location_t(location), cOpts)
@@ -1051,7 +1044,7 @@ func (v *Repository) ApplyToTree(diff *Diff, tree *Tree, opts *ApplyOptions) (*I
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateApplyOptions(&C.git_apply_options{}, opts, &err)
 	defer freeApplyOptions(cOpts)
 
 	var indexPtr *C.git_index

--- a/patch.go
+++ b/patch.go
@@ -78,7 +78,7 @@ func (v *Repository) PatchFromBuffers(oldPath, newPath string, oldBuf, newBuf []
 	defer C.free(unsafe.Pointer(cNewPath))
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()

--- a/reset.go
+++ b/reset.go
@@ -19,7 +19,7 @@ func (r *Repository) ResetToCommit(commit *Commit, resetType ResetType, opts *Ch
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_reset(r.ptr, commit.ptr, C.git_reset_t(resetType), cOpts)

--- a/revert.go
+++ b/revert.go
@@ -15,48 +15,47 @@ type RevertOptions struct {
 	CheckoutOpts CheckoutOptions
 }
 
-func (opts *RevertOptions) toC(errorTarget *error) *C.git_revert_options {
+func populateRevertOptions(copts *C.git_revert_options, opts *RevertOptions, errorTarget *error) *C.git_revert_options {
+	C.git_revert_init_options(copts, C.GIT_REVERT_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
-	return &C.git_revert_options{
-		version:       C.GIT_REVERT_OPTIONS_VERSION,
-		mainline:      C.uint(opts.Mainline),
-		merge_opts:    *opts.MergeOpts.toC(),
-		checkout_opts: *opts.CheckoutOpts.toC(errorTarget),
-	}
+	copts.mainline = C.uint(opts.Mainline)
+	populateMergeOptions(&copts.merge_opts, &opts.MergeOpts)
+	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOpts, errorTarget)
+	return copts
 }
 
-func revertOptionsFromC(opts *C.git_revert_options) RevertOptions {
+func revertOptionsFromC(copts *C.git_revert_options) RevertOptions {
 	return RevertOptions{
-		Mainline:     uint(opts.mainline),
-		MergeOpts:    mergeOptionsFromC(&opts.merge_opts),
-		CheckoutOpts: checkoutOptionsFromC(&opts.checkout_opts),
+		Mainline:     uint(copts.mainline),
+		MergeOpts:    mergeOptionsFromC(&copts.merge_opts),
+		CheckoutOpts: checkoutOptionsFromC(&copts.checkout_opts),
 	}
 }
 
-func freeRevertOptions(opts *C.git_revert_options) {
-	if opts != nil {
+func freeRevertOptions(copts *C.git_revert_options) {
+	if copts != nil {
 		return
 	}
-	freeMergeOptions(&opts.merge_opts)
-	freeCheckoutOptions(&opts.checkout_opts)
+	freeMergeOptions(&copts.merge_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
 }
 
 // DefaultRevertOptions initialises a RevertOptions struct with default values
 func DefaultRevertOptions() (RevertOptions, error) {
-	opts := C.git_revert_options{}
+	copts := C.git_revert_options{}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_revert_init_options(&opts, C.GIT_REVERT_OPTIONS_VERSION)
+	ecode := C.git_revert_init_options(&copts, C.GIT_REVERT_OPTIONS_VERSION)
 	if ecode < 0 {
 		return RevertOptions{}, MakeGitError(ecode)
 	}
 
-	defer freeRevertOptions(&opts)
-	return revertOptionsFromC(&opts), nil
+	defer freeRevertOptions(&copts)
+	return revertOptionsFromC(&copts), nil
 }
 
 // Revert the provided commit leaving the index updated with the results of the revert
@@ -65,7 +64,7 @@ func (r *Repository) Revert(commit *Commit, revertOptions *RevertOptions) error 
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := revertOptions.toC(&err)
+	cOpts := populateRevertOptions(&C.git_revert_options{}, revertOptions, &err)
 	defer freeRevertOptions(cOpts)
 
 	ret := C.git_revert(r.ptr, commit.cast_ptr, cOpts)
@@ -88,7 +87,7 @@ func (r *Repository) RevertCommit(revertCommit *Commit, ourCommit *Commit, mainl
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cOpts := mergeOptions.toC()
+	cOpts := populateMergeOptions(&C.git_merge_options{}, mergeOptions)
 	defer freeMergeOptions(cOpts)
 
 	var index *C.git_index

--- a/submodule.go
+++ b/submodule.go
@@ -383,22 +383,22 @@ func (sub *Submodule) Update(init bool, opts *SubmoduleUpdateOptions) error {
 	return nil
 }
 
-func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *SubmoduleUpdateOptions, errorTarget *error) *C.git_submodule_update_options {
-	C.git_submodule_update_init_options(ptr, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
-
+func populateSubmoduleUpdateOptions(copts *C.git_submodule_update_options, opts *SubmoduleUpdateOptions, errorTarget *error) *C.git_submodule_update_options {
+	C.git_submodule_update_init_options(copts, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
 
-	populateCheckoutOptions(&ptr.checkout_opts, opts.CheckoutOpts, errorTarget)
-	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
+	populateCheckoutOptions(&copts.checkout_opts, opts.CheckoutOpts, errorTarget)
+	populateFetchOptions(&copts.fetch_opts, opts.FetchOptions, errorTarget)
 
-	return ptr
+	return copts
 }
 
-func freeSubmoduleUpdateOptions(ptr *C.git_submodule_update_options) {
-	if ptr == nil {
+func freeSubmoduleUpdateOptions(copts *C.git_submodule_update_options) {
+	if copts == nil {
 		return
 	}
-	freeCheckoutOptions(&ptr.checkout_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
+	freeFetchOptions(&copts.fetch_opts)
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -13,7 +13,7 @@
 //
 //   // myfile.go
 //   type FooCallback func(...) (..., error)
-//   type FooCallbackData struct {
+//   type fooCallbackData struct {
 //     callback    FooCallback
 //     errorTarget *error
 //   }
@@ -59,20 +59,28 @@
 //     return git_my_function(..., (git_foo_cb)&fooCallback, payload);
 //   }
 //
-// * Otherwise, if the same callback can be invoked from multiple functions or
-//   from different stacks (e.g. when passing the callback to an object), a
-//   different pattern should be used instead, which has the downside of losing
-//   the original error object and converting it to a GitError:
+// * Additionally, if the same callback can be invoked from multiple functions or
+//   from different stacks (e.g. when passing the callback to an object), the
+//   following pattern should be used in tandem, which has the downside of
+//   losing the original error object and converting it to a GitError if the
+//   callback happens from a different stack:
 //
 //   // myfile.go
 //   type FooCallback func(...) (..., error)
+//   type fooCallbackData struct {
+//     callback    FooCallback
+//     errorTarget *error
+//   }
 //
 //   //export fooCallback
 //   func fooCallback(errorMessage **C.char, ..., handle unsafe.Pointer) C.int {
-//     callback := pointerHandles.Get(data).(*FooCallback)
+//     data := pointerHandles.Get(data).(*fooCallbackData)
 //     ...
-//     err := callback(...)
+//     err := data.callback(...)
 //     if err != nil {
+//       if data.errorTarget != nil {
+//         *data.errorTarget = err
+//       }
 //       return setCallbackError(errorMessage, err)
 //     }
 //     return C.int(ErrorCodeOK)


### PR DESCRIPTION
This change:

* Gets rid of the `.toC()` functions for Options objects, since they
  were redundant with the `populateXxxOptions()`.
* Adds support for `errorTarget` to the `RemoteOptions`, since they are
  used in the same stack for some functions (like `Fetch()`). Now for
  those cases, the error returned by the callback will be preserved
  as-is.

(cherry picked from commit 10c67474a89c298172a6703b91980ea37c60d5e5)