### PR TITLE
More callback refactoring (#713)

### DIFF
--- a/checkout.go
+++ b/checkout.go
@@ -88,13 +88,6 @@ func checkoutOptionsFromC(c *C.git_checkout_options) CheckoutOptions {
 	return opts
 }
 
-func (opts *CheckoutOptions) toC(errorTarget *error) *C.git_checkout_options {
-	if opts == nil {
-		return nil
-	}
-	return populateCheckoutOptions(&C.git_checkout_options{}, opts, errorTarget)
-}
-
 type checkoutCallbackData struct {
 	options     *CheckoutOptions
 	errorTarget *error
@@ -145,61 +138,61 @@ func checkoutProgressCallback(
 	data.options.ProgressCallback(C.GoString(path), uint(completed_steps), uint(total_steps))
 }
 
-// Convert the CheckoutOptions struct to the corresponding
-// C-struct. Returns a pointer to ptr, or nil if opts is nil, in order
-// to help with what to pass.
-func populateCheckoutOptions(ptr *C.git_checkout_options, opts *CheckoutOptions, errorTarget *error) *C.git_checkout_options {
+// populateCheckoutOptions populates the provided C-struct with the contents of
+// the provided CheckoutOptions struct.  Returns copts, or nil if opts is nil,
+// in order to help with what to pass.
+func populateCheckoutOptions(copts *C.git_checkout_options, opts *CheckoutOptions, errorTarget *error) *C.git_checkout_options {
+	C.git_checkout_init_options(copts, C.GIT_CHECKOUT_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
 
-	C.git_checkout_init_options(ptr, 1)
-	ptr.checkout_strategy = C.uint(opts.Strategy)
-	ptr.disable_filters = cbool(opts.DisableFilters)
-	ptr.dir_mode = C.uint(opts.DirMode.Perm())
-	ptr.file_mode = C.uint(opts.FileMode.Perm())
-	ptr.notify_flags = C.uint(opts.NotifyFlags)
+	copts.checkout_strategy = C.uint(opts.Strategy)
+	copts.disable_filters = cbool(opts.DisableFilters)
+	copts.dir_mode = C.uint(opts.DirMode.Perm())
+	copts.file_mode = C.uint(opts.FileMode.Perm())
+	copts.notify_flags = C.uint(opts.NotifyFlags)
 	if opts.NotifyCallback != nil || opts.ProgressCallback != nil {
-		C._go_git_populate_checkout_callbacks(ptr)
+		C._go_git_populate_checkout_callbacks(copts)
 		data := &checkoutCallbackData{
 			options:     opts,
 			errorTarget: errorTarget,
 		}
 		payload := pointerHandles.Track(data)
 		if opts.NotifyCallback != nil {
-			ptr.notify_payload = payload
+			copts.notify_payload = payload
 		}
 		if opts.ProgressCallback != nil {
-			ptr.progress_payload = payload
+			copts.progress_payload = payload
 		}
 	}
 	if opts.TargetDirectory != "" {
-		ptr.target_directory = C.CString(opts.TargetDirectory)
+		copts.target_directory = C.CString(opts.TargetDirectory)
 	}
 	if len(opts.Paths) > 0 {
-		ptr.paths.strings = makeCStringsFromStrings(opts.Paths)
-		ptr.paths.count = C.size_t(len(opts.Paths))
+		copts.paths.strings = makeCStringsFromStrings(opts.Paths)
+		copts.paths.count = C.size_t(len(opts.Paths))
 	}
 
 	if opts.Baseline != nil {
-		ptr.baseline = opts.Baseline.cast_ptr
+		copts.baseline = opts.Baseline.cast_ptr
 	}
 
-	return ptr
+	return copts
 }
 
-func freeCheckoutOptions(ptr *C.git_checkout_options) {
-	if ptr == nil {
+func freeCheckoutOptions(copts *C.git_checkout_options) {
+	if copts == nil {
 		return
 	}
-	C.free(unsafe.Pointer(ptr.target_directory))
-	if ptr.paths.count > 0 {
-		freeStrarray(&ptr.paths)
+	C.free(unsafe.Pointer(copts.target_directory))
+	if copts.paths.count > 0 {
+		freeStrarray(&copts.paths)
 	}
-	if ptr.notify_payload != nil {
-		pointerHandles.Untrack(ptr.notify_payload)
-	} else if ptr.progress_payload != nil {
-		pointerHandles.Untrack(ptr.progress_payload)
+	if copts.notify_payload != nil {
+		pointerHandles.Untrack(copts.notify_payload)
+	} else if copts.progress_payload != nil {
+		pointerHandles.Untrack(copts.progress_payload)
 	}
 }
 
@@ -210,7 +203,7 @@ func (v *Repository) CheckoutHead(opts *CheckoutOptions) error {
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_head(v.ptr, cOpts)
@@ -239,7 +232,7 @@ func (v *Repository) CheckoutIndex(index *Index, opts *CheckoutOptions) error {
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_index(v.ptr, iptr, cOpts)
@@ -259,7 +252,7 @@ func (v *Repository) CheckoutTree(tree *Tree, opts *CheckoutOptions) error {
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_checkout_tree(v.ptr, tree.ptr, cOpts)

--- a/clone.go
+++ b/clone.go
@@ -94,15 +94,14 @@ type cloneCallbackData struct {
 	errorTarget *error
 }
 
-func populateCloneOptions(ptr *C.git_clone_options, opts *CloneOptions, errorTarget *error) *C.git_clone_options {
-	C.git_clone_init_options(ptr, C.GIT_CLONE_OPTIONS_VERSION)
-
+func populateCloneOptions(copts *C.git_clone_options, opts *CloneOptions, errorTarget *error) *C.git_clone_options {
+	C.git_clone_init_options(copts, C.GIT_CLONE_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
-	populateCheckoutOptions(&ptr.checkout_opts, opts.CheckoutOpts, errorTarget)
-	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
-	ptr.bare = cbool(opts.Bare)
+	populateCheckoutOptions(&copts.checkout_opts, opts.CheckoutOpts, errorTarget)
+	populateFetchOptions(&copts.fetch_opts, opts.FetchOptions, errorTarget)
+	copts.bare = cbool(opts.Bare)
 
 	if opts.RemoteCreateCallback != nil {
 		data := &cloneCallbackData{
@@ -110,23 +109,24 @@ func populateCloneOptions(ptr *C.git_clone_options, opts *CloneOptions, errorTar
 			errorTarget: errorTarget,
 		}
 		// Go v1.1 does not allow to assign a C function pointer
-		C._go_git_populate_clone_callbacks(ptr)
-		ptr.remote_cb_payload = pointerHandles.Track(data)
+		C._go_git_populate_clone_callbacks(copts)
+		copts.remote_cb_payload = pointerHandles.Track(data)
 	}
 
-	return ptr
+	return copts
 }
 
-func freeCloneOptions(ptr *C.git_clone_options) {
-	if ptr == nil {
+func freeCloneOptions(copts *C.git_clone_options) {
+	if copts == nil {
 		return
 	}
 
-	freeCheckoutOptions(&ptr.checkout_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
+	freeFetchOptions(&copts.fetch_opts)
 
-	if ptr.remote_cb_payload != nil {
-		pointerHandles.Untrack(ptr.remote_cb_payload)
+	if copts.remote_cb_payload != nil {
+		pointerHandles.Untrack(copts.remote_cb_payload)
 	}
 
-	C.free(unsafe.Pointer(ptr.checkout_branch))
+	C.free(unsafe.Pointer(copts.checkout_branch))
 }

--- a/patch.go
+++ b/patch.go
@@ -78,7 +78,7 @@ func (v *Repository) PatchFromBuffers(oldPath, newPath string, oldBuf, newBuf []
 	defer C.free(unsafe.Pointer(cNewPath))
 
 	var err error
-	copts := opts.toC(v, &err)
+	copts := populateDiffOptions(&C.git_diff_options{}, opts, v, &err)
 	defer freeDiffOptions(copts)
 
 	runtime.LockOSThread()

--- a/reset.go
+++ b/reset.go
@@ -19,7 +19,7 @@ func (r *Repository) ResetToCommit(commit *Commit, resetType ResetType, opts *Ch
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := opts.toC(&err)
+	cOpts := populateCheckoutOptions(&C.git_checkout_options{}, opts, &err)
 	defer freeCheckoutOptions(cOpts)
 
 	ret := C.git_reset(r.ptr, commit.ptr, C.git_reset_t(resetType), cOpts)

--- a/revert.go
+++ b/revert.go
@@ -15,48 +15,47 @@ type RevertOptions struct {
 	CheckoutOpts CheckoutOptions
 }
 
-func (opts *RevertOptions) toC(errorTarget *error) *C.git_revert_options {
+func populateRevertOptions(copts *C.git_revert_options, opts *RevertOptions, errorTarget *error) *C.git_revert_options {
+	C.git_revert_init_options(copts, C.GIT_REVERT_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
-	return &C.git_revert_options{
-		version:       C.GIT_REVERT_OPTIONS_VERSION,
-		mainline:      C.uint(opts.Mainline),
-		merge_opts:    *opts.MergeOpts.toC(),
-		checkout_opts: *opts.CheckoutOpts.toC(errorTarget),
-	}
+	copts.mainline = C.uint(opts.Mainline)
+	populateMergeOptions(&copts.merge_opts, &opts.MergeOpts)
+	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOpts, errorTarget)
+	return copts
 }
 
-func revertOptionsFromC(opts *C.git_revert_options) RevertOptions {
+func revertOptionsFromC(copts *C.git_revert_options) RevertOptions {
 	return RevertOptions{
-		Mainline:     uint(opts.mainline),
-		MergeOpts:    mergeOptionsFromC(&opts.merge_opts),
-		CheckoutOpts: checkoutOptionsFromC(&opts.checkout_opts),
+		Mainline:     uint(copts.mainline),
+		MergeOpts:    mergeOptionsFromC(&copts.merge_opts),
+		CheckoutOpts: checkoutOptionsFromC(&copts.checkout_opts),
 	}
 }
 
-func freeRevertOptions(opts *C.git_revert_options) {
-	if opts != nil {
+func freeRevertOptions(copts *C.git_revert_options) {
+	if copts != nil {
 		return
 	}
-	freeMergeOptions(&opts.merge_opts)
-	freeCheckoutOptions(&opts.checkout_opts)
+	freeMergeOptions(&copts.merge_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
 }
 
 // DefaultRevertOptions initialises a RevertOptions struct with default values
 func DefaultRevertOptions() (RevertOptions, error) {
-	opts := C.git_revert_options{}
+	copts := C.git_revert_options{}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	ecode := C.git_revert_init_options(&opts, C.GIT_REVERT_OPTIONS_VERSION)
+	ecode := C.git_revert_init_options(&copts, C.GIT_REVERT_OPTIONS_VERSION)
 	if ecode < 0 {
 		return RevertOptions{}, MakeGitError(ecode)
 	}
 
-	defer freeRevertOptions(&opts)
-	return revertOptionsFromC(&opts), nil
+	defer freeRevertOptions(&copts)
+	return revertOptionsFromC(&copts), nil
 }
 
 // Revert the provided commit leaving the index updated with the results of the revert
@@ -65,7 +64,7 @@ func (r *Repository) Revert(commit *Commit, revertOptions *RevertOptions) error 
 	defer runtime.UnlockOSThread()
 
 	var err error
-	cOpts := revertOptions.toC(&err)
+	cOpts := populateRevertOptions(&C.git_revert_options{}, revertOptions, &err)
 	defer freeRevertOptions(cOpts)
 
 	ret := C.git_revert(r.ptr, commit.cast_ptr, cOpts)
@@ -88,7 +87,7 @@ func (r *Repository) RevertCommit(revertCommit *Commit, ourCommit *Commit, mainl
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cOpts := mergeOptions.toC()
+	cOpts := populateMergeOptions(&C.git_merge_options{}, mergeOptions)
 	defer freeMergeOptions(cOpts)
 
 	var index *C.git_index

--- a/submodule.go
+++ b/submodule.go
@@ -383,22 +383,22 @@ func (sub *Submodule) Update(init bool, opts *SubmoduleUpdateOptions) error {
 	return nil
 }
 
-func populateSubmoduleUpdateOptions(ptr *C.git_submodule_update_options, opts *SubmoduleUpdateOptions, errorTarget *error) *C.git_submodule_update_options {
-	C.git_submodule_update_init_options(ptr, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
-
+func populateSubmoduleUpdateOptions(copts *C.git_submodule_update_options, opts *SubmoduleUpdateOptions, errorTarget *error) *C.git_submodule_update_options {
+	C.git_submodule_update_init_options(copts, C.GIT_SUBMODULE_UPDATE_OPTIONS_VERSION)
 	if opts == nil {
 		return nil
 	}
 
-	populateCheckoutOptions(&ptr.checkout_opts, opts.CheckoutOpts, errorTarget)
-	populateFetchOptions(&ptr.fetch_opts, opts.FetchOptions)
+	populateCheckoutOptions(&copts.checkout_opts, opts.CheckoutOpts, errorTarget)
+	populateFetchOptions(&copts.fetch_opts, opts.FetchOptions, errorTarget)
 
-	return ptr
+	return copts
 }
 
-func freeSubmoduleUpdateOptions(ptr *C.git_submodule_update_options) {
-	if ptr == nil {
+func freeSubmoduleUpdateOptions(copts *C.git_submodule_update_options) {
+	if copts == nil {
 		return
 	}
-	freeCheckoutOptions(&ptr.checkout_opts)
+	freeCheckoutOptions(&copts.checkout_opts)
+	freeFetchOptions(&copts.fetch_opts)
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -13,7 +13,7 @@
 //
 //   // myfile.go
 //   type FooCallback func(...) (..., error)
-//   type FooCallbackData struct {
+//   type fooCallbackData struct {
 //     callback    FooCallback
 //     errorTarget *error
 //   }
@@ -59,20 +59,28 @@
 //     return git_my_function(..., (git_foo_cb)&fooCallback, payload);
 //   }
 //
-// * Otherwise, if the same callback can be invoked from multiple functions or
-//   from different stacks (e.g. when passing the callback to an object), a
-//   different pattern should be used instead, which has the downside of losing
-//   the original error object and converting it to a GitError:
+// * Additionally, if the same callback can be invoked from multiple functions or
+//   from different stacks (e.g. when passing the callback to an object), the
+//   following pattern should be used in tandem, which has the downside of
+//   losing the original error object and converting it to a GitError if the
+//   callback happens from a different stack:
 //
 //   // myfile.go
 //   type FooCallback func(...) (..., error)
+//   type fooCallbackData struct {
+//     callback    FooCallback
+//     errorTarget *error
+//   }
 //
 //   //export fooCallback
 //   func fooCallback(errorMessage **C.char, ..., handle unsafe.Pointer) C.int {
-//     callback := pointerHandles.Get(data).(*FooCallback)
+//     data := pointerHandles.Get(data).(*fooCallbackData)
 //     ...
-//     err := callback(...)
+//     err := data.callback(...)
 //     if err != nil {
+//       if data.errorTarget != nil {
+//         *data.errorTarget = err
+//       }
 //       return setCallbackError(errorMessage, err)
 //     }
 //     return C.int(ErrorCodeOK)


### PR DESCRIPTION
This change:

* Gets rid of the `.toC()` functions for Options objects, since they
  were redundant with the `populateXxxOptions()`.
* Adds support for `errorTarget` to the `RemoteOptions`, since they are
  used in the same stack for some functions (like `Fetch()`). Now for
  those cases, the error returned by the callback will be preserved
  as-is.

(cherry picked from commit 10c67474a89c298172a6703b91980ea37c60d5e5)