### PR TITLE
fix bundled static build on Windows/MinGW

### DIFF
--- a/Build_bundled_static.go
+++ b/Build_bundled_static.go
@@ -4,7 +4,7 @@ package git
 
 /*
 #cgo windows CFLAGS: -I${SRCDIR}/static-build/install/include/
-#cgo windows LDFLAGS: -L${SRCDIR}/static-build/install/lib/ -lgit2 -lwinhttp
+#cgo windows LDFLAGS: -L${SRCDIR}/static-build/install/lib/ -lgit2 -lwinhttp -lws2_32 -lole32 -lrpcrt4 -lcrypt32
 #cgo !windows pkg-config: --static ${SRCDIR}/static-build/install/lib/pkgconfig/libgit2.pc
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>


### PR DESCRIPTION
When building on Windows with MinGW using "bundled static" config, I am getting following errors

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\vbuzu\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -tags static -o C:\Users\vbuzu\AppData\Local\Temp\___1TestConfigLookups_in_github_com_libgit2_git2go_v31.exe github.com/libgit2/git2go/v31 #gosetup
# github.com/libgit2/git2go/v31
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(index.c.obj): In function `write_extension':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/index.c:2865: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(index.c.obj): In function `read_header':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/index.c:2537: undefined reference to `__imp_ntohl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(index.c.obj): In function `read_entry':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/index.c:2456: undefined reference to `__imp_ntohs'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/index.c:2465: undefined reference to `__imp_ntohs'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(index.c.obj): In function `write_index':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/index.c:3022: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(index.c.obj): In function `write_disk_entry':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/index.c:2781: undefined reference to `__imp_htons'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/index.c:2787: undefined reference to `__imp_htons'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(indexer.c.obj): In function `crc_object':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/indexer.c:317: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(indexer.c.obj): In function `parse_header':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/indexer.c:98: undefined reference to `__imp_ntohl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/indexer.c:103: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(indexer.c.obj): In function `update_header_and_rehash':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/indexer.c:1074: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(indexer.c.obj): In function `git_indexer_commit':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/indexer.c:1193: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(indexer.c.obj): In function `inject_object':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/indexer.c:911: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(pack-objects.c.obj): In function `write_pack':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/pack-objects.c:648: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(pack.c.obj):C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/pack.c:236: more undefined references to `__imp_htonl' follow
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(pack.c.obj): In function `pack_index_check':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/pack.c:245: undefined reference to `__imp_ntohl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(pack.c.obj): In function `packfile_open':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/pack.c:1055: undefined reference to `__imp_htonl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/pack.c:1060: undefined reference to `__imp_ntohl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(pack.c.obj): In function `pack_entry_find_offset':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/pack.c:1314: undefined reference to `__imp_ntohl'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(winhttp.c.obj): In function `acquire_fallback_cred':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/transports/winhttp.c:246: undefined reference to `__imp_CoInitializeEx'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/transports/winhttp.c:252: undefined reference to `__imp_CoCreateInstance'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/transports/winhttp.c:274: undefined reference to `__imp_CoUninitialize'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(winhttp.c.obj): In function `certificate_check':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/transports/winhttp.c:312: undefined reference to `__imp_CertFreeCertificateContext'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(winhttp.c.obj): In function `put_uuid_string':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/transports/winhttp.c:1278: undefined reference to `__imp_UuidCreate'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(posix_w32.c.obj): In function `p_recv':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/win32/posix_w32.c:908: undefined reference to `__imp_recv'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(posix_w32.c.obj): In function `p_send':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/win32/posix_w32.c:916: undefined reference to `__imp_send'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(posix_w32.c.obj): In function `p_inet_pton':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/win32/posix_w32.c:966: undefined reference to `__imp_WSAStringToAddressA'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/win32/posix_w32.c:971: undefined reference to `__imp_WSAGetLastError'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(socket.c.obj): In function `close_socket':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:57: undefined reference to `__imp_closesocket'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:60: undefined reference to `__imp_WSACleanup'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(socket.c.obj): In function `socket_connect':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:85: undefined reference to `__imp_WSAStartup'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:101: undefined reference to `__imp_getaddrinfo'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:107: undefined reference to `__imp_socket'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:113: undefined reference to `__imp_connect'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:124: undefined reference to `__imp_freeaddrinfo'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:129: undefined reference to `__imp_freeaddrinfo'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:91: undefined reference to `__imp_WSACleanup'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:102: undefined reference to `gai_strerrorA'
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/static-build/install/lib//libgit2.a(socket.c.obj): In function `net_set_error':
C:/Users/vbuzu/projects/vladimir-buzuev/git2go/vendor/libgit2/src/streams/socket.c:34: undefined reference to `__imp_WSAGetLastError'
collect2.exe: error: ld returned 1 exit status

Compilation finished with exit code 2
```

seems like need more libraries in LDFLAGS:

- ws2_32 for socket, connect, htonl, etc
- ole32 for CoInitializeEx 
- rpcrt4 for UuidCreate 
- crypt32 for CertFreeCertificateContext 
 