### PR TITLE
libgit2 v1.2.0 #major

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'release-1.0', 'release-0.28', 'release-0.27' ]
+        branch: [ 'release-1.1', 'release-1.0', 'release-0.28', 'release-0.27' ]
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         libgit2:
-          - 'v1.1.0'
-          - 'v1.2.0'
+          - '109b4c887ffb63962c7017a66fc4a1f48becb48e'  # v1.2.0 with a fixed symbol
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04

--- a/Build_bundled_static.go
+++ b/Build_bundled_static.go
@@ -1,3 +1,4 @@
+//go:build static && !system_libgit2
 // +build static,!system_libgit2
 
 package git
@@ -9,8 +10,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 2
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.2.0"
 #endif
 */
 import "C"

--- a/Build_system_dynamic.go
+++ b/Build_system_dynamic.go
@@ -1,3 +1,4 @@
+//go:build !static
 // +build !static
 
 package git
@@ -7,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 2
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.2.0"
 #endif
 */
 import "C"

--- a/Build_system_static.go
+++ b/Build_system_static.go
@@ -1,3 +1,4 @@
+//go:build static && system_libgit2
 // +build static,system_libgit2
 
 package git
@@ -7,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 2
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.2.0"
 #endif
 */
 import "C"

--- a/README.md
+++ b/README.md
@@ -10,20 +10,21 @@ Due to the fact that Go 1.11 module versions have semantic meaning and don't nec
 
 | libgit2 | git2go        |
 |---------|---------------|
-| main    | (will be v32) |
+| main    | (will be v33) |
+| 1.2     | v32           |
 | 1.1     | v31           |
 | 1.0     | v30           |
 | 0.99    | v29           |
 | 0.28    | v28           |
 | 0.27    | v27           |
 
-You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.1 installed, you'd import git2go v31 with:
+You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.2 installed, you'd import git2go v32 with:
 
 ```sh
-go get github.com/libgit2/git2go/v31
+go get github.com/libgit2/git2go/v32
 ```
 ```go
-import "github.com/libgit2/git2go/v31"
+import "github.com/libgit2/git2go/v32"
 ```
 
 which will ensure there are no sudden changes to the API.
@@ -44,10 +45,10 @@ This project wraps the functionality provided by libgit2. If you're using a vers
 
 ### Versioned branch, dynamic linking
 
-When linking dynamically against a released version of libgit2, install it via your system's package manager. CGo will take care of finding its pkg-config file and set up the linking. Import via Go modules, e.g. to work against libgit2 v1.1
+When linking dynamically against a released version of libgit2, install it via your system's package manager. CGo will take care of finding its pkg-config file and set up the linking. Import via Go modules, e.g. to work against libgit2 v1.2
 
 ```go
-import "github.com/libgit2/git2go/v31"
+import "github.com/libgit2/git2go/v32"
 ```
 
 ### Versioned branch, static linking
@@ -77,7 +78,7 @@ In order to let Go pass the correct flags to `pkg-config`, `-tags static` needs 
 
 One thing to take into account is that since Go expects the `pkg-config` file to be within the same directory where `make install-static` was called, so the `go.mod` file may need to have a [`replace` directive](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive) so that the correct setup is achieved. So if `git2go` is checked out at `$GOPATH/src/github.com/libgit2/git2go` and your project at `$GOPATH/src/github.com/my/project`, the `go.mod` file of `github.com/my/project` might need to have a line like
 
-    replace github.com/libgit2/git2go/v31 ../../libgit2/git2go
+    replace github.com/libgit2/git2go/v32 ../../libgit2/git2go
 
 Parallelism and network operations
 ----------------------------------

--- a/cherrypick.go
+++ b/cherrypick.go
@@ -9,18 +9,16 @@ import (
 )
 
 type CherrypickOptions struct {
-	Version      uint
-	Mainline     uint
-	MergeOpts    MergeOptions
-	CheckoutOpts CheckoutOptions
+	Mainline        uint
+	MergeOptions    MergeOptions
+	CheckoutOptions CheckoutOptions
 }
 
 func cherrypickOptionsFromC(c *C.git_cherrypick_options) CherrypickOptions {
 	opts := CherrypickOptions{
-		Version:      uint(c.version),
-		Mainline:     uint(c.mainline),
-		MergeOpts:    mergeOptionsFromC(&c.merge_opts),
-		CheckoutOpts: checkoutOptionsFromC(&c.checkout_opts),
+		Mainline:        uint(c.mainline),
+		MergeOptions:    mergeOptionsFromC(&c.merge_opts),
+		CheckoutOptions: checkoutOptionsFromC(&c.checkout_opts),
 	}
 	return opts
 }
@@ -31,8 +29,8 @@ func populateCherrypickOptions(copts *C.git_cherrypick_options, opts *Cherrypick
 		return nil
 	}
 	copts.mainline = C.uint(opts.Mainline)
-	populateMergeOptions(&copts.merge_opts, &opts.MergeOpts)
-	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOpts, errorTarget)
+	populateMergeOptions(&copts.merge_opts, &opts.MergeOptions)
+	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOptions, errorTarget)
 	return copts
 }
 
@@ -82,7 +80,7 @@ func (r *Repository) CherrypickCommit(pick, our *Commit, opts CherrypickOptions)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	cOpts := populateMergeOptions(&C.git_merge_options{}, &opts.MergeOpts)
+	cOpts := populateMergeOptions(&C.git_merge_options{}, &opts.MergeOptions)
 	defer freeMergeOptions(cOpts)
 
 	var ptr *C.git_index

--- a/clone.go
+++ b/clone.go
@@ -7,12 +7,11 @@ extern void _go_git_populate_clone_callbacks(git_clone_options *opts);
 */
 import "C"
 import (
-	"errors"
 	"runtime"
 	"unsafe"
 )
 
-type RemoteCreateCallback func(repo *Repository, name, url string) (*Remote, ErrorCode)
+type RemoteCreateCallback func(repo *Repository, name, url string) (*Remote, error)
 
 type CloneOptions struct {
 	*CheckoutOpts
@@ -71,9 +70,10 @@ func remoteCreateCallback(
 		panic("invalid remote create callback")
 	}
 
-	remote, ret := data.options.RemoteCreateCallback(repo, name, url)
-	if ret < 0 {
-		*data.errorTarget = errors.New(ErrorCode(ret).String())
+	remote, err := data.options.RemoteCreateCallback(repo, name, url)
+
+	if err != nil {
+		*data.errorTarget = err
 		return C.int(ErrorCodeUser)
 	}
 	if remote == nil {

--- a/clone.go
+++ b/clone.go
@@ -14,8 +14,8 @@ import (
 type RemoteCreateCallback func(repo *Repository, name, url string) (*Remote, error)
 
 type CloneOptions struct {
-	*CheckoutOpts
-	*FetchOptions
+	CheckoutOptions      CheckoutOptions
+	FetchOptions         FetchOptions
 	Bare                 bool
 	CheckoutBranch       string
 	RemoteCreateCallback RemoteCreateCallback
@@ -100,8 +100,8 @@ func populateCloneOptions(copts *C.git_clone_options, opts *CloneOptions, errorT
 	if opts == nil {
 		return nil
 	}
-	populateCheckoutOptions(&copts.checkout_opts, opts.CheckoutOpts, errorTarget)
-	populateFetchOptions(&copts.fetch_opts, opts.FetchOptions, errorTarget)
+	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOptions, errorTarget)
+	populateFetchOptions(&copts.fetch_opts, &opts.FetchOptions, errorTarget)
 	copts.bare = cbool(opts.Bare)
 
 	if opts.RemoteCreateCallback != nil {

--- a/clone_test.go
+++ b/clone_test.go
@@ -49,15 +49,9 @@ func TestCloneWithCallback(t *testing.T) {
 
 	opts := CloneOptions{
 		Bare: true,
-		RemoteCreateCallback: func(r *Repository, name, url string) (*Remote, ErrorCode) {
+		RemoteCreateCallback: func(r *Repository, name, url string) (*Remote, error) {
 			testPayload += 1
-
-			remote, err := r.Remotes.Create(REMOTENAME, url)
-			if err != nil {
-				return nil, ErrorCodeGeneric
-			}
-
-			return remote, ErrorCodeOK
+			return r.Remotes.Create(REMOTENAME, url)
 		},
 	}
 

--- a/deprecated.go
+++ b/deprecated.go
@@ -230,7 +230,11 @@ func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer) 
 	if !ok {
 		panic("invalid submodule visitor callback")
 	}
-	return (C.int)(callback(sub, C.GoString(name)))
+	err := callback(sub, C.GoString(name))
+	if err != nil {
+		return C.int(ErrorCodeUser)
+	}
+	return C.int(ErrorCodeOK)
 }
 
 // tree.go
@@ -239,9 +243,13 @@ func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer) 
 func CallbackGitTreeWalk(_root *C.char, entry *C.git_tree_entry, ptr unsafe.Pointer) C.int {
 	root := C.GoString(_root)
 
-	if callback, ok := pointerHandles.Get(ptr).(TreeWalkCallback); ok {
-		return C.int(callback(root, newTreeEntry(entry)))
-	} else {
+	callback, ok := pointerHandles.Get(ptr).(TreeWalkCallback)
+	if !ok {
 		panic("invalid treewalk callback")
 	}
+	err := callback(root, newTreeEntry(entry))
+	if err != nil {
+		return C.int(ErrorCodeUser)
+	}
+	return C.int(ErrorCodeOK)
 }

--- a/deprecated.go
+++ b/deprecated.go
@@ -237,6 +237,22 @@ func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer) 
 	return C.int(ErrorCodeOK)
 }
 
+// reference.go
+
+// Deprecated: ReferenceIsValidName is a deprecated alias of ReferenceNameIsValid.
+func ReferenceIsValidName(name string) bool {
+	valid, _ := ReferenceNameIsValid(name)
+	return valid
+}
+
+// remote.go
+
+// Deprecated: RemoteIsValidName is a deprecated alias of RemoteNameIsValid.
+func RemoteIsValidName(name string) bool {
+	valid, _ := RemoteNameIsValid(name)
+	return valid
+}
+
 // tree.go
 
 // Deprecated: CallbackGitTreeWalk is not used.

--- a/git.go
+++ b/git.go
@@ -227,7 +227,7 @@ func NewOid(s string) (*Oid, error) {
 	}
 
 	if len(slice) != 20 {
-		return nil, &GitError{"Invalid Oid", ErrorClassNone, ErrGeneric}
+		return nil, &GitError{"invalid oid", ErrorClassNone, ErrorCodeGeneric}
 	}
 
 	copy(o[:], slice[:20])

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libgit2/git2go/v31
+module github.com/libgit2/git2go/v32
 
 go 1.13
 

--- a/index.go
+++ b/index.go
@@ -10,13 +10,12 @@ extern int _go_git_index_remove_all(git_index*, const git_strarray*, void*);
 */
 import "C"
 import (
-	"errors"
 	"fmt"
 	"runtime"
 	"unsafe"
 )
 
-type IndexMatchedPathCallback func(string, string) int
+type IndexMatchedPathCallback func(string, string) error
 type indexMatchedPathCallbackData struct {
 	callback    IndexMatchedPathCallback
 	errorTarget *error
@@ -343,9 +342,9 @@ func indexMatchedPathCallback(cPath, cMatchedPathspec *C.char, payload unsafe.Po
 		panic("invalid matched path callback")
 	}
 
-	ret := data.callback(C.GoString(cPath), C.GoString(cMatchedPathspec))
-	if ret < 0 {
-		*data.errorTarget = errors.New(ErrorCode(ret).String())
+	err := data.callback(C.GoString(cPath), C.GoString(cMatchedPathspec))
+	if err != nil {
+		*data.errorTarget = err
 		return C.int(ErrorCodeUser)
 	}
 

--- a/index_test.go
+++ b/index_test.go
@@ -223,9 +223,9 @@ func TestIndexAddAllCallback(t *testing.T) {
 	checkFatal(t, err)
 
 	cbPath := ""
-	err = idx.AddAll([]string{}, IndexAddDefault, func(p, mP string) int {
+	err = idx.AddAll([]string{}, IndexAddDefault, func(p, mP string) error {
 		cbPath = p
-		return 0
+		return nil
 	})
 	checkFatal(t, err)
 	if cbPath != "README" {

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -33,9 +33,9 @@ func TestIndexerOutOfOrder(t *testing.T) {
 	defer os.RemoveAll(tmpPath)
 
 	var finalStats TransferProgress
-	idx, err := NewIndexer(tmpPath, nil, func(stats TransferProgress) ErrorCode {
+	idx, err := NewIndexer(tmpPath, nil, func(stats TransferProgress) error {
 		finalStats = stats
-		return ErrorCodeOK
+		return nil
 	})
 	checkFatal(t, err)
 	defer idx.Free()

--- a/merge.go
+++ b/merge.go
@@ -138,7 +138,6 @@ const (
 )
 
 type MergeOptions struct {
-	Version   uint
 	TreeFlags MergeTreeFlag
 
 	RenameThreshold uint
@@ -151,7 +150,6 @@ type MergeOptions struct {
 
 func mergeOptionsFromC(opts *C.git_merge_options) MergeOptions {
 	return MergeOptions{
-		Version:         uint(opts.version),
 		TreeFlags:       MergeTreeFlag(opts.flags),
 		RenameThreshold: uint(opts.rename_threshold),
 		TargetLimit:     uint(opts.target_limit),

--- a/odb_test.go
+++ b/odb_test.go
@@ -167,9 +167,9 @@ func TestOdbWritepack(t *testing.T) {
 	checkFatal(t, err)
 
 	var finalStats TransferProgress
-	writepack, err := odb.NewWritePack(func(stats TransferProgress) ErrorCode {
+	writepack, err := odb.NewWritePack(func(stats TransferProgress) error {
 		finalStats = stats
-		return ErrorCodeOK
+		return nil
 	})
 	checkFatal(t, err)
 	defer writepack.Free()

--- a/rebase.go
+++ b/rebase.go
@@ -130,7 +130,6 @@ func commitSigningCallback(errorMessage **C.char, _signature *C.git_buf, _signat
 
 // RebaseOptions are used to tell the rebase machinery how to operate
 type RebaseOptions struct {
-	Version               uint
 	Quiet                 int
 	InMemory              int
 	RewriteNotesRef       string
@@ -160,7 +159,6 @@ func DefaultRebaseOptions() (RebaseOptions, error) {
 
 func rebaseOptionsFromC(opts *C.git_rebase_options) RebaseOptions {
 	return RebaseOptions{
-		Version:         uint(opts.version),
 		Quiet:           int(opts.quiet),
 		InMemory:        int(opts.inmemory),
 		RewriteNotesRef: C.GoString(opts.rewrite_notes_ref),

--- a/reference_test.go
+++ b/reference_test.go
@@ -214,12 +214,16 @@ func TestIsNote(t *testing.T) {
 	}
 }
 
-func TestReferenceIsValidName(t *testing.T) {
+func TestReferenceNameIsValid(t *testing.T) {
 	t.Parallel()
-	if !ReferenceIsValidName("HEAD") {
+	valid, err := ReferenceNameIsValid("HEAD")
+	checkFatal(t, err)
+	if !valid {
 		t.Errorf("HEAD should be a valid reference name")
 	}
-	if ReferenceIsValidName("HEAD1") {
+	valid, err = ReferenceNameIsValid("HEAD1")
+	checkFatal(t, err)
+	if valid {
 		t.Errorf("HEAD1 should not be a valid reference name")
 	}
 }

--- a/remote.go
+++ b/remote.go
@@ -564,12 +564,20 @@ func freeProxyOptions(copts *C.git_proxy_options) {
 	C.free(unsafe.Pointer(copts.url))
 }
 
-// RemoteIsValidName returns whether the remote name is well-formed.
-func RemoteIsValidName(name string) bool {
+// RemoteNameIsValid returns whether the remote name is well-formed.
+func RemoteNameIsValid(name string) (bool, error) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	return C.git_remote_is_valid_name(cname) == 1
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var valid C.int
+	ret := C.git_remote_name_is_valid(&valid, cname)
+	if ret < 0 {
+		return false, MakeGitError(ret)
+	}
+	return valid == 1, nil
 }
 
 // free releases the resources of the Remote.

--- a/remote_test.go
+++ b/remote_test.go
@@ -38,13 +38,13 @@ func TestListRemotes(t *testing.T) {
 	compareStringList(t, expected, actual)
 }
 
-func assertHostname(cert *Certificate, valid bool, hostname string, t *testing.T) ErrorCode {
+func assertHostname(cert *Certificate, valid bool, hostname string, t *testing.T) error {
 	if hostname != "github.com" {
-		t.Fatal("Hostname does not match")
-		return ErrorCodeUser
+		t.Fatal("hostname does not match")
+		return errors.New("hostname does not match")
 	}
 
-	return ErrorCodeOK
+	return nil
 }
 
 func TestCertificateCheck(t *testing.T) {
@@ -58,7 +58,7 @@ func TestCertificateCheck(t *testing.T) {
 
 	options := FetchOptions{
 		RemoteCallbacks: RemoteCallbacks{
-			CertificateCheckCallback: func(cert *Certificate, valid bool, hostname string) ErrorCode {
+			CertificateCheckCallback: func(cert *Certificate, valid bool, hostname string) error {
 				return assertHostname(cert, valid, hostname, t)
 			},
 		},
@@ -479,14 +479,13 @@ func TestRemoteSSH(t *testing.T) {
 	certificateCheckCallbackCalled := false
 	fetchOpts := FetchOptions{
 		RemoteCallbacks: RemoteCallbacks{
-			CertificateCheckCallback: func(cert *Certificate, valid bool, hostname string) ErrorCode {
+			CertificateCheckCallback: func(cert *Certificate, valid bool, hostname string) error {
 				hostkeyFingerprint := fmt.Sprintf("%x", cert.Hostkey.HashMD5[:])
 				if hostkeyFingerprint != publicKeyFingerprint {
-					t.Logf("server hostkey %q, want %q", hostkeyFingerprint, publicKeyFingerprint)
-					return ErrorCodeAuth
+					return fmt.Errorf("server hostkey %q, want %q", hostkeyFingerprint, publicKeyFingerprint)
 				}
 				certificateCheckCallbackCalled = true
-				return ErrorCodeOK
+				return nil
 			},
 			CredentialsCallback: func(url, username string, allowedTypes CredentialType) (*Credential, error) {
 				if allowedTypes&(CredentialTypeSSHKey|CredentialTypeSSHCustom|CredentialTypeSSHMemory) != 0 {

--- a/revert.go
+++ b/revert.go
@@ -10,9 +10,9 @@ import (
 
 // RevertOptions contains options for performing a revert
 type RevertOptions struct {
-	Mainline     uint
-	MergeOpts    MergeOptions
-	CheckoutOpts CheckoutOptions
+	Mainline        uint
+	MergeOptions    MergeOptions
+	CheckoutOptions CheckoutOptions
 }
 
 func populateRevertOptions(copts *C.git_revert_options, opts *RevertOptions, errorTarget *error) *C.git_revert_options {
@@ -21,16 +21,16 @@ func populateRevertOptions(copts *C.git_revert_options, opts *RevertOptions, err
 		return nil
 	}
 	copts.mainline = C.uint(opts.Mainline)
-	populateMergeOptions(&copts.merge_opts, &opts.MergeOpts)
-	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOpts, errorTarget)
+	populateMergeOptions(&copts.merge_opts, &opts.MergeOptions)
+	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOptions, errorTarget)
 	return copts
 }
 
 func revertOptionsFromC(copts *C.git_revert_options) RevertOptions {
 	return RevertOptions{
-		Mainline:     uint(copts.mainline),
-		MergeOpts:    mergeOptionsFromC(&copts.merge_opts),
-		CheckoutOpts: checkoutOptionsFromC(&copts.checkout_opts),
+		Mainline:        uint(copts.mainline),
+		MergeOptions:    mergeOptionsFromC(&copts.merge_opts),
+		CheckoutOptions: checkoutOptionsFromC(&copts.checkout_opts),
 	}
 }
 

--- a/revert_test.go
+++ b/revert_test.go
@@ -60,11 +60,11 @@ func TestRevertCommit(t *testing.T) {
 	revertOptions, err := DefaultRevertOptions()
 	checkFatal(t, err)
 
-	index, err := repo.RevertCommit(commit, commit, 0, &revertOptions.MergeOpts)
+	index, err := repo.RevertCommit(commit, commit, 0, &revertOptions.MergeOptions)
 	checkFatal(t, err)
 	defer index.Free()
 
-	err = repo.CheckoutIndex(index, &revertOptions.CheckoutOpts)
+	err = repo.CheckoutIndex(index, &revertOptions.CheckoutOptions)
 	checkFatal(t, err)
 
 	actualReadmeContents := readReadme(t, repo)

--- a/submodule.go
+++ b/submodule.go
@@ -8,7 +8,6 @@ extern int _go_git_visit_submodule(git_repository *repo, void *fct);
 import "C"
 
 import (
-	"errors"
 	"runtime"
 	"unsafe"
 )
@@ -111,7 +110,7 @@ func (c *SubmoduleCollection) Lookup(name string) (*Submodule, error) {
 }
 
 // SubmoduleCallback is a function that is called for every submodule found in SubmoduleCollection.Foreach.
-type SubmoduleCallback func(sub *Submodule, name string) int
+type SubmoduleCallback func(sub *Submodule, name string) error
 type submoduleCallbackData struct {
 	callback    SubmoduleCallback
 	errorTarget *error
@@ -126,9 +125,9 @@ func submoduleCallback(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer)
 		panic("invalid submodule visitor callback")
 	}
 
-	ret := data.callback(sub, C.GoString(name))
-	if ret < 0 {
-		*data.errorTarget = errors.New(ErrorCode(ret).String())
+	err := data.callback(sub, C.GoString(name))
+	if err != nil {
+		*data.errorTarget = err
 		return C.int(ErrorCodeUser)
 	}
 

--- a/submodule.go
+++ b/submodule.go
@@ -14,8 +14,8 @@ import (
 
 // SubmoduleUpdateOptions
 type SubmoduleUpdateOptions struct {
-	*CheckoutOpts
-	*FetchOptions
+	CheckoutOptions CheckoutOptions
+	FetchOptions    FetchOptions
 }
 
 // Submodule
@@ -390,8 +390,8 @@ func populateSubmoduleUpdateOptions(copts *C.git_submodule_update_options, opts 
 		return nil
 	}
 
-	populateCheckoutOptions(&copts.checkout_opts, opts.CheckoutOpts, errorTarget)
-	populateFetchOptions(&copts.fetch_opts, opts.FetchOptions, errorTarget)
+	populateCheckoutOptions(&copts.checkout_opts, &opts.CheckoutOptions, errorTarget)
+	populateFetchOptions(&copts.fetch_opts, &opts.FetchOptions, errorTarget)
 
 	return copts
 }

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -15,9 +15,9 @@ func TestSubmoduleForeach(t *testing.T) {
 	checkFatal(t, err)
 
 	i := 0
-	err = repo.Submodules.Foreach(func(sub *Submodule, name string) int {
+	err = repo.Submodules.Foreach(func(sub *Submodule, name string) error {
 		i++
-		return 0
+		return nil
 	})
 	checkFatal(t, err)
 

--- a/tree.go
+++ b/tree.go
@@ -8,7 +8,6 @@ extern int _go_git_treewalk(git_tree *tree, git_treewalk_mode mode, void *ptr);
 import "C"
 
 import (
-	"errors"
 	"runtime"
 	"unsafe"
 )
@@ -121,7 +120,7 @@ func (t *Tree) EntryCount() uint64 {
 	return uint64(num)
 }
 
-type TreeWalkCallback func(string, *TreeEntry) int
+type TreeWalkCallback func(string, *TreeEntry) error
 type treeWalkCallbackData struct {
 	callback    TreeWalkCallback
 	errorTarget *error
@@ -134,9 +133,9 @@ func treeWalkCallback(_root *C.char, entry *C.git_tree_entry, ptr unsafe.Pointer
 		panic("invalid treewalk callback")
 	}
 
-	ret := data.callback(C.GoString(_root), newTreeEntry(entry))
-	if ret < 0 {
-		*data.errorTarget = errors.New(ErrorCode(ret).String())
+	err := data.callback(C.GoString(_root), newTreeEntry(entry))
+	if err != nil {
+		*data.errorTarget = err
 		return C.int(ErrorCodeUser)
 	}
 

--- a/wrapper.c
+++ b/wrapper.c
@@ -116,18 +116,28 @@ void _go_git_populate_apply_callbacks(git_apply_options *options)
 	options->hunk_cb = (git_apply_hunk_cb)&hunkApplyCallback;
 }
 
-static int commit_signing_callback(
-		git_buf *signature,
-		git_buf *signature_field,
-		const char *commit_contents,
+static int commit_create_callback(
+		git_oid *out,
+		const git_signature *author,
+		const git_signature *committer,
+		const char *message_encoding,
+		const char *message,
+		const git_tree *tree,
+		size_t parent_count,
+		const git_commit *parents[],
 		void *payload)
 {
 	char *error_message = NULL;
-	const int ret = commitSigningCallback(
+	const int ret = commitCreateCallback(
 			&error_message,
-			signature,
-			signature_field,
-			(char *)commit_contents,
+			out,
+			(git_signature *)author,
+			(git_signature *)committer,
+			(char *)message_encoding,
+			(char *)message,
+			(git_tree *)tree,
+			parent_count,
+			(git_commit **)parents,
 			payload
 	);
 	return set_callback_error(error_message, ret);
@@ -135,7 +145,7 @@ static int commit_signing_callback(
 
 void _go_git_populate_rebase_callbacks(git_rebase_options *opts)
 {
-	opts->signing_cb = commit_signing_callback;
+	opts->commit_create_cb = commit_create_callback;
 }
 
 void _go_git_populate_clone_callbacks(git_clone_options *opts)


### PR DESCRIPTION
This commit introduces libgit2 v1.2.0 to git2go, which brings a large
number of [bugfixes and
features](https://github.com/libgit2/libgit2/releases/tag/v1.2.0).

This also marks the start of the v32 release.

Fixes: #775 