### PR TITLE
Remove the legacy builders (#776)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,11 +7,12 @@ on:
 jobs:
 
   backport:
+    name: Backport change to branch ${{ matrix.branch }}
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
         branch: [ 'release-0.28', 'release-0.27' ]
-    name: Backport change to branch ${{ matrix.branch }}
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,45 +9,11 @@ on:
 
 jobs:
 
-  build-legacy:
-    strategy:
-      fail-fast: false
-      matrix:
-        go: [ '1.9', '1.10' ]
-    name: Go ${{ matrix.go }}
-
-    runs-on: ubuntu-18.04
-
-    steps:
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go }}
-      id: go
-    - name: Check out code into the GOPATH
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-        path: src/github.com/${{ github.repository }}
-    - name: Build
-      env:
-        GOPATH: /home/runner/work/git2go
-      run: |
-        git submodule update --init
-        sudo apt-get install -y --no-install-recommends libssh2-1-dev
-        make build-libgit2-static
-        go get -tags static -t github.com/${{ github.repository }}/...
-        go build -tags static github.com/${{ github.repository }}/...
-    - name: Test
-      env:
-        GOPATH: /home/runner/work/git2go
-      run: make TEST_ARGS=-test.v test-static
-
   build-static:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.11', '1.12', '1.13', '1.14', '1.15' ]
+        go: [ '1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17' ]
     name: Go ${{ matrix.go }}
 
     runs-on: ubuntu-20.04
@@ -79,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.15'
+        go-version: '1.17'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -104,7 +70,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.15'
+        go-version: '1.17'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -127,7 +93,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.15'
+        go-version: '1.17'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1


### PR DESCRIPTION
These builds are no longer working because some of the dependencies now
require newer versions of Go. Seems like the ecosystem has moved to Go
1.11+, so we are now forced to follow suit.

(cherry picked from commit df7084d36a771e4ef2a418c7d3c4367d920e4cf3)