### PR TITLE
Add `Repository.CreateCommitBuffer` (#781)

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -12,6 +12,14 @@ import (
 	"unsafe"
 )
 
+// MessageEncoding is the encoding of commit messages.
+type MessageEncoding string
+
+const (
+	// MessageEncodingUTF8 is the default message encoding.
+	MessageEncodingUTF8 MessageEncoding = "UTF-8"
+)
+
 // Commit
 type Commit struct {
 	Object


### PR DESCRIPTION
This commit adds the Go binding for `git_commit_create_buffer`. This
will be used to support the 1.2.0 commit create callback.

(cherry picked from commit fbaf9d1d1ae0bb7b6e7ed9044945d4c9322d4c76)