### PR TITLE
Declare forward-compatibility with libgit2 v1.2.0  #minor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libgit2: [ '1.1.0' ]
+        libgit2:
+          - 'v1.1.0'
+          - 'v1.2.0'
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04
@@ -78,7 +80,7 @@ jobs:
       run: |
         git submodule update --init
         sudo apt-get install -y --no-install-recommends libssh2-1-dev
-        sudo env BUILD_LIBGIT_REF=v${{ matrix.libgit2 }} ./script/build-libgit2.sh --dynamic --system
+        sudo env BUILD_LIBGIT_REF=${{ matrix.libgit2 }} ./script/build-libgit2.sh --dynamic --system
     - name: Test
       run: make TEST_ARGS=-test.v test
 

--- a/Build_bundled_static.go
+++ b/Build_bundled_static.go
@@ -9,8 +9,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 1
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
 #endif
 */
 import "C"

--- a/Build_system_dynamic.go
+++ b/Build_system_dynamic.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 1
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
 #endif
 */
 import "C"

--- a/Build_system_static.go
+++ b/Build_system_static.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 1
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.1.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
 #endif
 */
 import "C"

--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -51,8 +51,11 @@ if [ -n "${BUILD_LIBGIT_REF}" ]; then
 	trap "git submodule update --init" EXIT
 fi
 
+BUILD_DEPRECATED_HARD="ON"
 if [ "${BUILD_SYSTEM}" = "ON" ]; then
 	BUILD_INSTALL_PREFIX=${SYSTEM_INSTALL_PREFIX-"/usr"}
+	# Most system-wide installations won't intentionally omit deprecated symbols.
+	BUILD_DEPRECATED_HARD="OFF"
 else
 	BUILD_INSTALL_PREFIX="${BUILD_PATH}/install"
 	mkdir -p "${BUILD_PATH}/install/lib"
@@ -68,7 +71,7 @@ cmake -DTHREADSAFE=ON \
       -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
       -DCMAKE_INSTALL_PREFIX="${BUILD_INSTALL_PREFIX}" \
       -DCMAKE_INSTALL_LIBDIR="lib" \
-      -DDEPRECATE_HARD=ON \
+      -DDEPRECATE_HARD="${BUILD_DEPRECATE_HARD}" \
       "${VENDORED_PATH}"
 
 if which make nproc >/dev/null && [ -f Makefile ]; then


### PR DESCRIPTION
We can't yet ship a fully libgit2 v1.2.0-compatible library due to a
missing public symbol, but we can allow the v1.1.0-era codebase to link
against libgit2 v1.2.0 in the meantime.