### PR TITLE
Make all non-user-creatable structures non-comparable (#802)

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -86,6 +86,7 @@ func (v *Repository) BlameFile(path string, opts *BlameOptions) (*Blame, error) 
 }
 
 type Blame struct {
+	doNotCompare
 	ptr *C.git_blame
 }
 

--- a/blob.go
+++ b/blob.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Blob struct {
+	doNotCompare
 	Object
 	cast_ptr *C.git_blob
 }
@@ -96,6 +97,7 @@ func (repo *Repository) CreateFromStream(hintPath string) (*BlobWriteStream, err
 }
 
 type BlobWriteStream struct {
+	doNotCompare
 	ptr  *C.git_writestream
 	repo *Repository
 }

--- a/branch.go
+++ b/branch.go
@@ -19,6 +19,7 @@ const (
 )
 
 type Branch struct {
+	doNotCompare
 	*Reference
 }
 
@@ -27,6 +28,7 @@ func (r *Reference) Branch() *Branch {
 }
 
 type BranchIterator struct {
+	doNotCompare
 	ptr  *C.git_branch_iterator
 	repo *Repository
 }

--- a/commit.go
+++ b/commit.go
@@ -22,6 +22,7 @@ const (
 
 // Commit
 type Commit struct {
+	doNotCompare
 	Object
 	cast_ptr *C.git_commit
 }

--- a/config.go
+++ b/config.go
@@ -52,6 +52,7 @@ func newConfigEntryFromC(centry *C.git_config_entry) *ConfigEntry {
 }
 
 type Config struct {
+	doNotCompare
 	ptr *C.git_config
 }
 
@@ -361,6 +362,7 @@ func OpenOndisk(path string) (*Config, error) {
 }
 
 type ConfigIterator struct {
+	doNotCompare
 	ptr *C.git_config_iterator
 	cfg *Config
 }

--- a/credentials.go
+++ b/credentials.go
@@ -23,6 +23,7 @@ const (
 )
 
 type Cred struct {
+	doNotCompare
 	ptr *C.git_cred
 }
 
@@ -38,7 +39,7 @@ func (o *Cred) Type() CredType {
 }
 
 func credFromC(ptr *C.git_cred) *Cred {
-	return &Cred{ptr}
+	return &Cred{ptr: ptr}
 }
 
 func NewCredUserpassPlaintext(username string, password string) (int, Cred) {

--- a/deprecated.go
+++ b/deprecated.go
@@ -179,7 +179,7 @@ type SubmoduleCbk = SubmoduleCallback
 
 // Deprecated: SubmoduleVisitor is not used.
 func SubmoduleVisitor(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer) C.int {
-	sub := &Submodule{(*C.git_submodule)(csub), nil}
+	sub := &Submodule{ptr: (*C.git_submodule)(csub)}
 
 	callback, ok := pointerHandles.Get(handle).(SubmoduleCallback)
 	if !ok {

--- a/describe.go
+++ b/describe.go
@@ -176,6 +176,7 @@ func (repo *Repository) DescribeWorkdir(opts *DescribeOptions) (*DescribeResult,
 //
 // Use Format() to get a string out of it.
 type DescribeResult struct {
+	doNotCompare
 	ptr *C.git_describe_result
 }
 

--- a/diff.go
+++ b/diff.go
@@ -132,6 +132,7 @@ func diffLineFromC(line *C.git_diff_line) DiffLine {
 }
 
 type Diff struct {
+	doNotCompare
 	ptr          *C.git_diff
 	repo         *Repository
 	runFinalizer bool
@@ -219,6 +220,7 @@ func (diff *Diff) FindSimilar(opts *DiffFindOptions) error {
 }
 
 type DiffStats struct {
+	doNotCompare
 	ptr *C.git_diff_stats
 }
 

--- a/git.go
+++ b/git.go
@@ -123,6 +123,10 @@ var (
 	ErrInvalid = errors.New("Invalid state for operation")
 )
 
+// doNotCompare is an idiomatic way of making structs non-comparable to avoid
+// future field additions to make them non-comparable.
+type doNotCompare [0]func()
+
 var pointerHandles *HandleList
 
 func init() {

--- a/handles.go
+++ b/handles.go
@@ -11,6 +11,7 @@ import (
 )
 
 type HandleList struct {
+	doNotCompare
 	sync.RWMutex
 	// stores the Go pointers
 	handles map[unsafe.Pointer]interface{}

--- a/index.go
+++ b/index.go
@@ -52,6 +52,7 @@ const (
 )
 
 type Index struct {
+	doNotCompare
 	ptr  *C.git_index
 	repo *Repository
 }
@@ -108,7 +109,7 @@ func freeCIndexEntry(entry *C.git_index_entry) {
 }
 
 func newIndexFromC(ptr *C.git_index, repo *Repository) *Index {
-	idx := &Index{ptr, repo}
+	idx := &Index{ptr: ptr, repo: repo}
 	runtime.SetFinalizer(idx, (*Index).Free)
 	return idx
 }
@@ -616,6 +617,7 @@ func (v *Index) RemoveConflict(path string) error {
 }
 
 type IndexConflictIterator struct {
+	doNotCompare
 	ptr   *C.git_index_conflict_iterator
 	index *Index
 }

--- a/indexer.go
+++ b/indexer.go
@@ -19,6 +19,7 @@ import (
 // Indexer can post-process packfiles and create an .idx file for efficient
 // lookup.
 type Indexer struct {
+	doNotCompare
 	ptr        *C.git_indexer
 	stats      C.git_transfer_progress
 	ccallbacks C.git_remote_callbacks

--- a/mempack.go
+++ b/mempack.go
@@ -18,6 +18,7 @@ import (
 
 // Mempack is a custom ODB backend that permits packing object in-memory.
 type Mempack struct {
+	doNotCompare
 	ptr *C.git_odb_backend
 }
 

--- a/merge.go
+++ b/merge.go
@@ -17,6 +17,7 @@ import (
 )
 
 type AnnotatedCommit struct {
+	doNotCompare
 	ptr *C.git_annotated_commit
 	r   *Repository
 }
@@ -426,11 +427,12 @@ func (r *Repository) MergeBaseOctopus(oids []*Oid) (*Oid, error) {
 }
 
 type MergeFileResult struct {
+	doNotCompare
+	ptr           *C.git_merge_file_result
 	Automergeable bool
 	Path          string
 	Mode          uint
 	Contents      []byte
-	ptr           *C.git_merge_file_result
 }
 
 func newMergeFileResultFromC(c *C.git_merge_file_result) *MergeFileResult {

--- a/note.go
+++ b/note.go
@@ -13,6 +13,7 @@ import (
 // This object represents the possible operations which can be
 // performed on the collection of notes for a repository.
 type NoteCollection struct {
+	doNotCompare
 	repo *Repository
 }
 
@@ -139,6 +140,7 @@ func (c *NoteCollection) DefaultRef() (string, error) {
 
 // Note
 type Note struct {
+	doNotCompare
 	ptr *C.git_note
 	r   *Repository
 }
@@ -189,6 +191,7 @@ func (n *Note) Message() string {
 
 // NoteIterator
 type NoteIterator struct {
+	doNotCompare
 	ptr *C.git_note_iterator
 	r   *Repository
 }

--- a/object.go
+++ b/object.go
@@ -22,6 +22,7 @@ const (
 )
 
 type Object struct {
+	doNotCompare
 	ptr  *C.git_object
 	repo *Repository
 }

--- a/odb.go
+++ b/odb.go
@@ -22,10 +22,12 @@ import (
 )
 
 type Odb struct {
+	doNotCompare
 	ptr *C.git_odb
 }
 
 type OdbBackend struct {
+	doNotCompare
 	ptr *C.git_odb_backend
 }
 
@@ -45,7 +47,7 @@ func NewOdb() (odb *Odb, err error) {
 }
 
 func NewOdbBackendFromC(ptr unsafe.Pointer) (backend *OdbBackend) {
-	backend = &OdbBackend{(*C.git_odb_backend)(ptr)}
+	backend = &OdbBackend{ptr: (*C.git_odb_backend)(ptr)}
 	return backend
 }
 
@@ -313,6 +315,7 @@ func (v *OdbBackend) Free() {
 }
 
 type OdbObject struct {
+	doNotCompare
 	ptr *C.git_odb_object
 }
 
@@ -356,6 +359,7 @@ func (object *OdbObject) Data() (data []byte) {
 }
 
 type OdbReadStream struct {
+	doNotCompare
 	ptr  *C.git_odb_stream
 	Size uint64
 	Type ObjectType
@@ -396,6 +400,7 @@ func (stream *OdbReadStream) Free() {
 }
 
 type OdbWriteStream struct {
+	doNotCompare
 	ptr *C.git_odb_stream
 	Id  Oid
 }
@@ -440,6 +445,7 @@ func (stream *OdbWriteStream) Free() {
 
 // OdbWritepack is a stream to write a packfile to the ODB.
 type OdbWritepack struct {
+	doNotCompare
 	ptr        *C.git_odb_writepack
 	stats      C.git_transfer_progress
 	ccallbacks C.git_remote_callbacks

--- a/packbuilder.go
+++ b/packbuilder.go
@@ -16,6 +16,7 @@ import (
 )
 
 type Packbuilder struct {
+	doNotCompare
 	ptr *C.git_packbuilder
 	r   *Repository
 }

--- a/patch.go
+++ b/patch.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Patch struct {
+	doNotCompare
 	ptr *C.git_patch
 }
 

--- a/rebase.go
+++ b/rebase.go
@@ -142,6 +142,7 @@ func mapEmptyStringToNull(ref string) *C.char {
 
 // Rebase is the struct representing a Rebase object.
 type Rebase struct {
+	doNotCompare
 	ptr     *C.git_rebase
 	r       *Repository
 	options *C.git_rebase_options

--- a/refdb.go
+++ b/refdb.go
@@ -13,11 +13,13 @@ import (
 )
 
 type Refdb struct {
+	doNotCompare
 	ptr *C.git_refdb
 	r   *Repository
 }
 
 type RefdbBackend struct {
+	doNotCompare
 	ptr *C.git_refdb_backend
 }
 
@@ -38,7 +40,7 @@ func (v *Repository) NewRefdb() (refdb *Refdb, err error) {
 }
 
 func NewRefdbBackendFromC(ptr unsafe.Pointer) (backend *RefdbBackend) {
-	backend = &RefdbBackend{(*C.git_refdb_backend)(ptr)}
+	backend = &RefdbBackend{ptr: (*C.git_refdb_backend)(ptr)}
 	return backend
 }
 

--- a/reference.go
+++ b/reference.go
@@ -17,11 +17,13 @@ const (
 )
 
 type Reference struct {
+	doNotCompare
 	ptr  *C.git_reference
 	repo *Repository
 }
 
 type ReferenceCollection struct {
+	doNotCompare
 	repo *Repository
 }
 
@@ -363,11 +365,13 @@ func (v *Reference) Free() {
 }
 
 type ReferenceIterator struct {
+	doNotCompare
 	ptr  *C.git_reference_iterator
 	repo *Repository
 }
 
 type ReferenceNameIterator struct {
+	doNotCompare
 	*ReferenceIterator
 }
 
@@ -422,7 +426,7 @@ func (repo *Repository) NewReferenceIteratorGlob(glob string) (*ReferenceIterato
 }
 
 func (i *ReferenceIterator) Names() *ReferenceNameIterator {
-	return &ReferenceNameIterator{i}
+	return &ReferenceNameIterator{ReferenceIterator: i}
 }
 
 // NextName retrieves the next reference name. If the iteration is over,

--- a/remote.go
+++ b/remote.go
@@ -167,6 +167,7 @@ type ProxyOptions struct {
 }
 
 type Remote struct {
+	doNotCompare
 	ptr       *C.git_remote
 	callbacks RemoteCallbacks
 	repo      *Repository
@@ -515,6 +516,7 @@ func (r *Remote) Free() {
 }
 
 type RemoteCollection struct {
+	doNotCompare
 	repo *Repository
 }
 

--- a/repository.go
+++ b/repository.go
@@ -14,6 +14,7 @@ import (
 
 // Repository
 type Repository struct {
+	doNotCompare
 	ptr *C.git_repository
 	// Remotes represents the collection of remotes and can be
 	// used to add, remove and configure remotes for this

--- a/revparse.go
+++ b/revparse.go
@@ -20,6 +20,7 @@ const (
 )
 
 type Revspec struct {
+	doNotCompare
 	to    *Object
 	from  *Object
 	flags RevparseFlag

--- a/stash.go
+++ b/stash.go
@@ -35,6 +35,7 @@ const (
 // StashCollection represents the possible operations that can be
 // performed on the collection of stashes for a repository.
 type StashCollection struct {
+	doNotCompare
 	repo *Repository
 }
 

--- a/status.go
+++ b/status.go
@@ -55,6 +55,7 @@ func statusEntryFromC(statusEntry *C.git_status_entry) StatusEntry {
 }
 
 type StatusList struct {
+	doNotCompare
 	ptr *C.git_status_list
 	r   *Repository
 }

--- a/submodule.go
+++ b/submodule.go
@@ -21,6 +21,7 @@ type SubmoduleUpdateOptions struct {
 
 // Submodule
 type Submodule struct {
+	doNotCompare
 	ptr *C.git_submodule
 	r   *Repository
 }
@@ -82,6 +83,7 @@ const (
 )
 
 type SubmoduleCollection struct {
+	doNotCompare
 	repo *Repository
 }
 
@@ -117,7 +119,7 @@ type submoduleCallbackData struct {
 
 //export submoduleCallback
 func submoduleCallback(csub unsafe.Pointer, name *C.char, handle unsafe.Pointer) C.int {
-	sub := &Submodule{(*C.git_submodule)(csub), nil}
+	sub := &Submodule{ptr: (*C.git_submodule)(csub)}
 
 	data, ok := pointerHandles.Get(handle).(submoduleCallbackData)
 	if !ok {

--- a/tag.go
+++ b/tag.go
@@ -13,6 +13,7 @@ import (
 
 // Tag
 type Tag struct {
+	doNotCompare
 	Object
 	cast_ptr *C.git_tag
 }
@@ -64,6 +65,7 @@ func (t *Tag) TargetType() ObjectType {
 }
 
 type TagsCollection struct {
+	doNotCompare
 	repo *Repository
 }
 

--- a/tree.go
+++ b/tree.go
@@ -24,6 +24,7 @@ const (
 )
 
 type Tree struct {
+	doNotCompare
 	Object
 	cast_ptr *C.git_tree
 }
@@ -167,6 +168,7 @@ func (t *Tree) Walk(callback TreeWalkCallback) error {
 }
 
 type TreeBuilder struct {
+	doNotCompare
 	ptr  *C.git_treebuilder
 	repo *Repository
 }

--- a/walk.go
+++ b/walk.go
@@ -22,6 +22,7 @@ const (
 )
 
 type RevWalk struct {
+	doNotCompare
 	ptr  *C.git_revwalk
 	repo *Repository
 }


### PR DESCRIPTION
This change makes all non-user-creatable structures non-comparable. This
makes it easier to add changes later that don't introduce breaking
changes from the go compatibility guarantees perspective.

This, of course, implies that this change _is_ a breaking change, but since
these structures are not intended to be created by users (or de-referenced),
it should be okay.

(cherry picked from commit dbe032c347b1a1308a4b880e7c5a06d8dfb4d507)