### PR TITLE
Allow building libgit2 with Chromium zlib

### DIFF
--- a/script/build-libgit2.sh
+++ b/script/build-libgit2.sh
@@ -61,12 +61,18 @@ else
 	mkdir -p "${BUILD_PATH}/install/lib"
 fi
 
+USE_BUNDLED_ZLIB="ON"
+if [ "${USE_CHROMIUM_ZLIB}" = "ON" ]; then
+	USE_BUNDLED_ZLIB="Chromium"
+fi
+
 mkdir -p "${BUILD_PATH}/build" &&
 cd "${BUILD_PATH}/build" &&
 cmake -DTHREADSAFE=ON \
       -DBUILD_CLAR=OFF \
       -DBUILD_SHARED_LIBS"=${BUILD_SHARED_LIBS}" \
       -DREGEX_BACKEND=builtin \
+      -DUSE_BUNDLED_ZLIB="${USE_BUNDLED_ZLIB}" \
       -DUSE_HTTPS=OFF \
       -DUSE_SSH=OFF \
       -DCMAKE_C_FLAGS=-fPIC \


### PR DESCRIPTION
This change allows the caller to set the `USE_CHROMIUM_ZLIB=ON`
environment variable to use the Chromium implementation of zlib when
building libgit2.