### PR TITLE
Allow skipping an entry expansion in `tree.Walk()`

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -1,6 +1,9 @@
 package git
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestTreeEntryById(t *testing.T) {
 	t.Parallel()
@@ -61,5 +64,74 @@ func TestTreeBuilderInsert(t *testing.T) {
 
 	if !entry.Id.Equal(blobId) {
 		t.Fatalf("got oid %v, want %v", entry.Id, blobId)
+	}
+}
+
+func TestTreeWalk(t *testing.T) {
+	t.Parallel()
+	repo, err := OpenRepository("testdata/TestGitRepository.git")
+	checkFatal(t, err)
+	treeID, err := NewOid("6020a3b8d5d636e549ccbd0c53e2764684bb3125")
+	checkFatal(t, err)
+
+	tree, err := repo.LookupTree(treeID)
+	checkFatal(t, err)
+
+	var callCount int
+	err = tree.Walk(func(name string, entry *TreeEntry) error {
+		callCount++
+
+		return nil
+	})
+	checkFatal(t, err)
+	if callCount != 11 {
+		t.Fatalf("got called %v times, want %v", callCount, 11)
+	}
+}
+
+func TestTreeWalkSkip(t *testing.T) {
+	t.Parallel()
+	repo, err := OpenRepository("testdata/TestGitRepository.git")
+	checkFatal(t, err)
+	treeID, err := NewOid("6020a3b8d5d636e549ccbd0c53e2764684bb3125")
+	checkFatal(t, err)
+
+	tree, err := repo.LookupTree(treeID)
+	checkFatal(t, err)
+
+	var callCount int
+	err = tree.Walk(func(name string, entry *TreeEntry) error {
+		callCount++
+
+		return TreeWalkSkip
+	})
+	checkFatal(t, err)
+	if callCount != 4 {
+		t.Fatalf("got called %v times, want %v", callCount, 4)
+	}
+}
+
+func TestTreeWalkStop(t *testing.T) {
+	t.Parallel()
+	repo, err := OpenRepository("testdata/TestGitRepository.git")
+	checkFatal(t, err)
+	treeID, err := NewOid("6020a3b8d5d636e549ccbd0c53e2764684bb3125")
+	checkFatal(t, err)
+
+	tree, err := repo.LookupTree(treeID)
+	checkFatal(t, err)
+
+	var callCount int
+	stopError := errors.New("stop")
+	err = tree.Walk(func(name string, entry *TreeEntry) error {
+		callCount++
+
+		return stopError
+	})
+	if err != stopError {
+		t.Fatalf("got error %v, want %v", err, stopError)
+	}
+	if callCount != 1 {
+		t.Fatalf("got called %v times, want %v", callCount, 1)
 	}
 }


### PR DESCRIPTION
It is now possible to skip expanding an entry in `tree.Walk()` by
returning `TreeWalkSkip`, in addition to stopping altogether by
returning a non-nil error.

Fixes: #837