### PR TITLE
Generate stringer files automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,4 +120,4 @@ jobs:
     - name: Generate files
       run: make generate
     - name: Check nothing changed
-      run: git diff --quiet --exit-code || (echo "detected changes after generate" && exit 1)
+      run: git diff --quiet --exit-code || (echo "detected changes after generate" ; git status ; exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
       run: |
         git submodule update --init
         sudo apt-get install -y --no-install-recommends libssh2-1-dev
+        go install golang.org/x/tools/cmd/stringer@latest
     - name: Generate files
       run: make generate
     - name: Check nothing changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+    - name: Install libgit2 build dependencies
+      run: |
+        git submodule update --init
+        sudo apt-get install -y --no-install-recommends libssh2-1-dev
     - name: Generate files
       run: make generate
     - name: Check nothing changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
         sudo apt-get install -y --no-install-recommends libssh2-1-dev
         go install golang.org/x/tools/cmd/stringer@latest
     - name: Generate files
-      run: make generate
+      run: |
+        export PATH=$(go env GOPATH)/bin:$PATH
+        make generate
     - name: Check nothing changed
       run: git diff --quiet --exit-code || (echo "detected changes after generate" ; git status ; exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,19 @@ jobs:
         sudo ./script/build-libgit2.sh --static --system
     - name: Test
       run: go test --count=1 --tags "static,system_libgit2" ./...
+
+  check-generate:
+    name: Check generated files were not modified
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.17'
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Generate files
+      run: make generate
+    - name: Check nothing changed
+      run: git diff --quiet --exit-code || (echo "detected changes after generate" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,17 @@ test-static: static-build/install/lib/libgit2.a
 
 install-static: static-build/install/lib/libgit2.a
 	go install --tags "static" ./...
+
+define _gen_file
+	rm -fr _obj
+	go tool cgo $(1)
+	find ./_obj -type f ! -name '*.go' -exec rm {} \;
+	mv ./_obj/_cgo_gotypes.go ./_obj/cgo_gotypes.go
+	cd ./_obj && go generate ./...
+	find ./_obj -type f -name '*_string.go' -exec mv -v {} . \;
+	rm -fr ./_obj
+endef
+
+generate:
+	$(call _gen_file,diff.go)
+	$(call _gen_file,git.go)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ TEST_ARGS ?= --count=1
 
 default: test
 
+
+generate: static-build/install/lib/libgit2.a
+	go generate --tags "static" ./...
+
 # System library
 # ==============
 # This uses whatever version of libgit2 can be found in the system.
@@ -53,17 +57,3 @@ test-static: static-build/install/lib/libgit2.a
 
 install-static: static-build/install/lib/libgit2.a
 	go install --tags "static" ./...
-
-define _gen_file
-	rm -fr _obj
-	go tool cgo $(1)
-	find ./_obj -type f ! -name '*.go' -exec rm {} \;
-	mv ./_obj/_cgo_gotypes.go ./_obj/cgo_gotypes.go
-	cd ./_obj && go generate ./...
-	find ./_obj -type f -name '*_string.go' -exec mv -v {} . \;
-	rm -fr ./_obj
-endef
-
-generate:
-	$(call _gen_file,diff.go)
-	$(call _gen_file,git.go)

--- a/git.go
+++ b/git.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 )
 
+//go:generate stringer -type ErrorClass -trimprefix ErrorClass -tags static
 type ErrorClass int
 
 const (
@@ -48,6 +49,7 @@ const (
 	ErrorClassPatch      ErrorClass = C.GIT_ERROR_PATCH
 )
 
+//go:generate stringer -type ErrorCode -trimprefix ErrorCode -tags static
 type ErrorCode int
 
 const (


### PR DESCRIPTION
Added `stringer` annotations to `git.go` for `ErrorClass` and
`ErrorCode`. Added `generate` rule for `Makefile` to generate
string representations for these types (first building cgo files
in `_obj` dir to get C constants). Finally, updated `ci` actions
workflow to check that generated files are up to date.

Fixes: #543