### PR TITLE
Declare forward-compatibility with libgit2 v1.3.0  #minor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       matrix:
         libgit2:
           - '109b4c887ffb63962c7017a66fc4a1f48becb48e'  # v1.2.0 with a fixed symbol
+          - 'v1.3.0'
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04

--- a/Build_bundled_static.go
+++ b/Build_bundled_static.go
@@ -10,8 +10,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 3
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.3.0"
 #endif
 */
 import "C"

--- a/Build_system_dynamic.go
+++ b/Build_system_dynamic.go
@@ -8,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 3
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.3.0"
 #endif
 */
 import "C"

--- a/Build_system_static.go
+++ b/Build_system_static.go
@@ -8,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 2 || LIBGIT2_VER_MINOR > 3
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.2.0 and v1.3.0"
 #endif
 */
 import "C"


### PR DESCRIPTION
This commit marks this (Golang) version of git2go as being compatible
with libgit2 v1.3.0.