### PR TITLE
Declare forward-compatibility with libgit2 v1.3.0  #minor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         libgit2:
           - 'v1.1.0'
           - 'v1.2.0'
+          - 'v1.3.0'
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04

--- a/Build_bundled_static.go
+++ b/Build_bundled_static.go
@@ -9,8 +9,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 3
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.3.0"
 #endif
 */
 import "C"

--- a/Build_system_dynamic.go
+++ b/Build_system_dynamic.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 3
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.3.0"
 #endif
 */
 import "C"

--- a/Build_system_static.go
+++ b/Build_system_static.go
@@ -7,8 +7,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 2
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.2.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 1 || LIBGIT2_VER_MINOR > 3
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.1.0 and v1.3.0"
 #endif
 */
 import "C"


### PR DESCRIPTION
This commit marks this (Golang) version of git2go as being compatible
with libgit2 v1.3.0.