### PR TITLE
Make ssh commands used in the git smart transport compatible with libgit2

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -76,8 +76,8 @@ func (t *sshSmartSubtransport) Action(urlString string, action SmartServiceActio
 	}
 
 	// Escape \ and '.
-	uPath := strings.ReplaceAll(u.Path, `\`, `\\`)
-	uPath = strings.ReplaceAll(uPath, `'`, `\'`)
+	uPath := strings.Replace(u.Path, `\`, `\\`, -1)
+	uPath = strings.Replace(uPath, `'`, `\'`, -1)
 
 	// TODO: Add percentage decode similar to libgit2.
 	// Refer: https://github.com/libgit2/libgit2/blob/358a60e1b46000ea99ef10b4dd709e92f75ff74b/src/str.c#L455-L481

--- a/ssh.go
+++ b/ssh.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/url"
 	"runtime"
+	"strings"
 	"unsafe"
 
 	"golang.org/x/crypto/ssh"
@@ -74,6 +75,13 @@ func (t *sshSmartSubtransport) Action(urlString string, action SmartServiceActio
 		return nil, err
 	}
 
+	// Escape \ and '.
+	uPath := strings.ReplaceAll(u.Path, `\`, `\\`)
+	uPath = strings.ReplaceAll(uPath, `'`, `\'`)
+
+	// TODO: Add percentage decode similar to libgit2.
+	// Refer: https://github.com/libgit2/libgit2/blob/358a60e1b46000ea99ef10b4dd709e92f75ff74b/src/str.c#L455-L481
+
 	var cmd string
 	switch action {
 	case SmartServiceActionUploadpackLs, SmartServiceActionUploadpack:
@@ -83,7 +91,7 @@ func (t *sshSmartSubtransport) Action(urlString string, action SmartServiceActio
 			}
 			t.Close()
 		}
-		cmd = fmt.Sprintf("git-upload-pack %q", u.Path)
+		cmd = fmt.Sprintf("git-upload-pack '%s'", uPath)
 
 	case SmartServiceActionReceivepackLs, SmartServiceActionReceivepack:
 		if t.currentStream != nil {
@@ -92,7 +100,7 @@ func (t *sshSmartSubtransport) Action(urlString string, action SmartServiceActio
 			}
 			t.Close()
 		}
-		cmd = fmt.Sprintf("git-receive-pack %q", u.Path)
+		cmd = fmt.Sprintf("git-receive-pack '%s'", uPath)
 
 	default:
 		return nil, fmt.Errorf("unexpected action: %v", action)


### PR DESCRIPTION
Before this change, the commands sent to the git server were of the form:

```
git-upload-pack "/bar/test-reponame"
```

This resulted in the git server ([gitkit](https://github.com/sosedoff/gitkit)) returning error:
`error parsing command: invalid git command`

This change replaces the double quotes with single quotes:

```
git-upload-pack '/bar/test-reponame'
```

Using git smart transport via managed ssh transport against gitkit, fails with the following errors:

```console
2021/11/07 21:57:24 ssh: incoming exec request: git-upload-pack "/bar/test-reponame"
2021/11/07 21:57:24 ssh: payload 'git-upload-pack "/bar/test-reponame"'
2021/11/07 21:57:24 ssh: error parsing command: invalid git command
```
Resulting in a clone failure: `unable to clone: EOF`.

Using ssh transport based on the libgit2 libraries work with gitkit.
Upon further investigation, I found that gitkit has a [regular expression](https://github.com/sosedoff/gitkit/blob/99577b562191e1a27b81dfb2d569ea54452d77e9/git_command.go#L9) for parsing the commands and it fails to parse commands with `"` (double quote). Replacing the double quotes with single quote fixes the issue.
It felt like a bug in gitkit itself. So I wasn't sure if we should fix it in git2go. But after going through the libgit2 code, I found that the libgit2 implementation also uses single quotes, refer: https://github.com/libgit2/libgit2/blob/358a60e1b46000ea99ef10b4dd709e92f75ff74b/src/transports/ssh.c#L96-L99.

I guess it'd be better if we are consistent with libgit2 to maintain compatibility.