### PR TITLE
Generate stringer files automatically (#841)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,26 @@ jobs:
         sudo ./script/build-libgit2.sh --static --system
     - name: Test
       run: go test --count=1 --tags "static,system_libgit2" ./...
+
+  check-generate:
+    name: Check generated files were not modified
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.17'
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Install libgit2 build dependencies
+      run: |
+        git submodule update --init
+        sudo apt-get install -y --no-install-recommends libssh2-1-dev
+        go install golang.org/x/tools/cmd/stringer@latest
+    - name: Generate files
+      run: |
+        export PATH=$(go env GOPATH)/bin:$PATH
+        make generate
+    - name: Check nothing changed
+      run: git diff --quiet --exit-code || (echo "detected changes after generate" ; git status ; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ TEST_ARGS ?= --count=1
 
 default: test
 
+
+generate: static-build/install/lib/libgit2.a
+	go generate --tags "static" ./...
+
 # System library
 # ==============
 # This uses whatever version of libgit2 can be found in the system.

--- a/git.go
+++ b/git.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 )
 
+//go:generate stringer -type ErrorClass -trimprefix ErrorClass -tags static
 type ErrorClass int
 
 const (
@@ -48,6 +49,7 @@ const (
 	ErrorClassPatch      ErrorClass = C.GIT_ERROR_PATCH
 )
 
+//go:generate stringer -type ErrorCode -trimprefix ErrorCode -tags static
 type ErrorCode int
 
 const (


### PR DESCRIPTION
Added `stringer` annotations to `git.go` for `ErrorClass` and
`ErrorCode`. Added `generate` rule for `Makefile` to generate
string representations for these types (first building cgo files
in `_obj` dir to get C constants). Finally, updated `ci` actions
workflow to check that generated files are up to date.

Fixes: #543
(cherry picked from commit 5e35338d58b589939b599c98ec9e6b44f94de20a)