### PR TITLE
libgit2 v1.5.0 #major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         libgit2:
-          - 'v1.3.1'
+          - '1d88605ca9d51f9e8695030853d5914743fbb091'
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04

--- a/Build_bundled_static.go
+++ b/Build_bundled_static.go
@@ -10,8 +10,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 3 || LIBGIT2_VER_MINOR > 3
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.3.0 and v1.3.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 5 || LIBGIT2_VER_MINOR > 5
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.5.0 and v1.5.0"
 #endif
 */
 import "C"

--- a/Build_system_dynamic.go
+++ b/Build_system_dynamic.go
@@ -8,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 3 || LIBGIT2_VER_MINOR > 3
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.3.0 and v1.3.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 5 || LIBGIT2_VER_MINOR > 5
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.5.0 and v1.5.0"
 #endif
 */
 import "C"

--- a/Build_system_static.go
+++ b/Build_system_static.go
@@ -8,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 3 || LIBGIT2_VER_MINOR > 3
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.3.0 and v1.3.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 5 || LIBGIT2_VER_MINOR > 5
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.5.0 and v1.5.0"
 #endif
 */
 import "C"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 git2go
 ======
-[![GoDoc](https://godoc.org/github.com/libgit2/git2go?status.svg)](http://godoc.org/github.com/libgit2/git2go/v33) [![Build Status](https://travis-ci.org/libgit2/git2go.svg?branch=main)](https://travis-ci.org/libgit2/git2go)
+[![GoDoc](https://godoc.org/github.com/libgit2/git2go?status.svg)](http://godoc.org/github.com/libgit2/git2go/v34) [![Build Status](https://travis-ci.org/libgit2/git2go.svg?branch=main)](https://travis-ci.org/libgit2/git2go)
 
 Go bindings for [libgit2](http://libgit2.github.com/).
 
@@ -10,7 +10,8 @@ Due to the fact that Go 1.11 module versions have semantic meaning and don't nec
 
 | libgit2 | git2go        |
 |---------|---------------|
-| main    | (will be v34) |
+| main    | (will be v35) |
+| 1.4     | v34           |
 | 1.3     | v33           |
 | 1.2     | v32           |
 | 1.1     | v31           |
@@ -19,13 +20,13 @@ Due to the fact that Go 1.11 module versions have semantic meaning and don't nec
 | 0.28    | v28           |
 | 0.27    | v27           |
 
-You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.2 installed, you'd import git2go v33 with:
+You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.4 installed, you'd import git2go v34 with:
 
 ```sh
-go get github.com/libgit2/git2go/v33
+go get github.com/libgit2/git2go/v34
 ```
 ```go
-import "github.com/libgit2/git2go/v33"
+import "github.com/libgit2/git2go/v34"
 ```
 
 which will ensure there are no sudden changes to the API.
@@ -46,10 +47,10 @@ This project wraps the functionality provided by libgit2. If you're using a vers
 
 ### Versioned branch, dynamic linking
 
-When linking dynamically against a released version of libgit2, install it via your system's package manager. CGo will take care of finding its pkg-config file and set up the linking. Import via Go modules, e.g. to work against libgit2 v1.2
+When linking dynamically against a released version of libgit2, install it via your system's package manager. CGo will take care of finding its pkg-config file and set up the linking. Import via Go modules, e.g. to work against libgit2 v1.4
 
 ```go
-import "github.com/libgit2/git2go/v33"
+import "github.com/libgit2/git2go/v34"
 ```
 
 ### Versioned branch, static linking
@@ -79,7 +80,7 @@ In order to let Go pass the correct flags to `pkg-config`, `-tags static` needs 
 
 One thing to take into account is that since Go expects the `pkg-config` file to be within the same directory where `make install-static` was called, so the `go.mod` file may need to have a [`replace` directive](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive) so that the correct setup is achieved. So if `git2go` is checked out at `$GOPATH/src/github.com/libgit2/git2go` and your project at `$GOPATH/src/github.com/my/project`, the `go.mod` file of `github.com/my/project` might need to have a line like
 
-    replace github.com/libgit2/git2go/v33 => ../../libgit2/git2go
+    replace github.com/libgit2/git2go/v34 => ../../libgit2/git2go
 
 Parallelism and network operations
 ----------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libgit2/git2go/v33
+module github.com/libgit2/git2go/v34
 
 go 1.13
 

--- a/http.go
+++ b/http.go
@@ -38,17 +38,17 @@ func registerManagedHTTP() error {
 
 func httpSmartSubtransportFactory(remote *Remote, transport *Transport) (SmartSubtransport, error) {
 	var proxyFn func(*http.Request) (*url.URL, error)
-	proxyOpts, err := transport.SmartProxyOptions()
+	connectOpts, err := transport.SmartRemoteConnectOptions()
 	if err != nil {
 		return nil, err
 	}
-	switch proxyOpts.Type {
+	switch connectOpts.ProxyOpts.Type {
 	case ProxyTypeNone:
 		proxyFn = nil
 	case ProxyTypeAuto:
 		proxyFn = http.ProxyFromEnvironment
 	case ProxyTypeSpecified:
-		parsedUrl, err := url.Parse(proxyOpts.Url)
+		parsedUrl, err := url.Parse(connectOpts.ProxyOpts.Url)
 		if err != nil {
 			return nil, err
 		}

--- a/transport.go
+++ b/transport.go
@@ -4,6 +4,7 @@ package git
 #include <string.h>
 
 #include <git2.h>
+#include <git2/sys/remote.h>
 #include <git2/sys/transport.h>
 
 typedef struct {
@@ -84,17 +85,19 @@ type Transport struct {
 	ptr *C.git_transport
 }
 
-// SmartProxyOptions gets a copy of the proxy options for this transport.
-func (t *Transport) SmartProxyOptions() (*ProxyOptions, error) {
+// SmartRemoteConnectOptions gets a copy of the connection options for this transport.
+func (t *Transport) SmartRemoteConnectOptions() (*RemoteConnectOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	var cpopts C.git_proxy_options
-	if ret := C.git_transport_smart_proxy_options(&cpopts, t.ptr); ret < 0 {
+	var copts C.git_remote_connect_options
+	if ret := C.git_transport_smart_remote_connect_options(&copts, t.ptr); ret < 0 {
 		return nil, MakeGitError(ret)
 	}
+	opts := remoteConnectOptionsFromC(&copts)
+	C.git_remote_connect_options_dispose(&copts)
 
-	return proxyOptionsFromC(&cpopts), nil
+	return opts, nil
 }
 
 // SmartCredentials calls the credentials callback for this transport.


### PR DESCRIPTION
This commit introduces libgit2 v1.5.0-alpha to git2go, which brings a
large number of bugfixes and features.

This also marks the start of the v34 release.