### PR TITLE
Allow retrieving/setting repository owner validation

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -134,6 +134,22 @@ func SetCacheObjectLimit(objectType ObjectType, size int) error {
 	return nil
 }
 
+func OwnerValidation() (enabled bool, err error) {
+	val, err := getSizet(C.GIT_OPT_GET_OWNER_VALIDATION)
+	if val == 1 {
+		return true, err
+	}
+	return false, err
+}
+
+func SetOwnerValidation(enabled bool) error {
+	if enabled {
+		return setSizet(C.GIT_OPT_SET_OWNER_VALIDATION, 1)
+	} else {
+		return setSizet(C.GIT_OPT_SET_OWNER_VALIDATION, 0)
+	}
+}
+
 func getSizet(opt C.int) (int, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/settings_test.go
+++ b/settings_test.go
@@ -97,3 +97,27 @@ func TestSetCacheMaxSize(t *testing.T) {
 	err = SetCacheMaxSize(256 * 1024 * 1024)
 	checkFatal(t, err)
 }
+
+func TestOwnerValidation(t *testing.T) {
+	enabled, err := OwnerValidation()
+	checkFatal(t, err)
+
+	err = SetOwnerValidation(!enabled)
+	checkFatal(t, err)
+
+	var enabled2 bool
+	enabled2, err = OwnerValidation()
+	checkFatal(t, err)
+
+	if enabled == enabled2 {
+		t.Fatal("set owner validation failed")
+	}
+}
+
+func TestSetOwnerValidation(t *testing.T) {
+	err := SetOwnerValidation(false)
+	checkFatal(t, err)
+
+	err = SetOwnerValidation(true)
+	checkFatal(t, err)
+}


### PR DESCRIPTION
Uses the `GIT_OPT_GET_OWNER_VALIDATION` and `GIT_OPT_SET_OWNER_VALIDATION` options introduced in https://github.com/libgit2/libgit2/commit/4161ebdd50dc29205dcc94cba5320c6d0d2537a7