### PR TITLE
Set BasicAuth in http.go only if username and password are not empty

### DIFF
--- a/http.go
+++ b/http.go
@@ -203,7 +203,9 @@ func (self *httpSmartSubtransportStream) sendRequest() error {
 			req.ContentLength = -1
 		}
 
-		req.SetBasicAuth(userName, password)
+		if userName != "" && password != "" {
+			req.SetBasicAuth(userName, password)
+		}
 		resp, err = http.DefaultClient.Do(req)
 		if err != nil {
 			return err


### PR DESCRIPTION
This prevents error "read/write on closed pipe".

Go's http.client::send() always closes req.Body, so if the first request attempt
is unsuccessful, any subsequent requests after calling the `CredentialsCallback`
will attempt to read/write on a closed pipe.