### PR TITLE
Allow use of libgit2 built without thread support

### DIFF
--- a/git.go
+++ b/git.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"os"
 	"runtime"
 	"strings"
 	"unsafe"
@@ -148,7 +149,7 @@ func initLibGit2() {
 	// with multi-threading support. The most likely outcome is a segfault
 	// or panic at an incomprehensible time, so let's make it easy by
 	// panicking right here.
-	if features&FeatureThreads == 0 {
+	if features&FeatureThreads == 0 && !strings.EqualFold(os.Getenv("ALLOW_THREADLESS_LIBGIT2"), "true") {
 		panic("libgit2 was not built with threading support")
 	}
 


### PR DESCRIPTION
Allow use of libgit2 built without thread support.

With smart transport, users using solely Managed Transports can rely on Go to deal with the multi-threading requirements of transport management.

To enable threadless libgit2 an environment variable `ALLOW_THREADLESS_LIBGIT2` must be set to `true`.

As long as the git2go objects are not being shared across Go routines this arrangement seems to work well.

By leveraging this and the removal of unmanaged transport we have experienced a decrease in segfaults or random errors when using git2go for accessing multiple Git repositories concurrently.

Fixes #917.