### PR TITLE
Add packbuilder.SetCallbacks()

### DIFF
--- a/odb.go
+++ b/odb.go
@@ -64,6 +64,21 @@ func (v *Odb) AddAlternate(backend *OdbBackend, priority int) (err error) {
 	return nil
 }
 
+func (v *Odb) AddDiskAlternate(path string) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	cstr := C.CString(path)
+	defer C.free(unsafe.Pointer(cstr))
+
+	ret := C.git_odb_add_disk_alternate(v.ptr, cstr)
+	runtime.KeepAlive(v)
+	if ret < 0 {
+		return MakeGitError(ret)
+	}
+	return nil
+}
+
 func (v *Odb) AddBackend(backend *OdbBackend, priority int) (err error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/wrapper.c
+++ b/wrapper.c
@@ -322,6 +322,24 @@ static int pack_progress_callback(int stage, unsigned int current, unsigned int 
 	return set_callback_error(error_message, ret);
 }
 
+static int packbuilder_progress_callback(int stage, unsigned int current, unsigned int total, void *data)
+{
+	char *error_message = NULL;
+	const int ret = packbuilderProgressCallback(
+			&error_message,
+			stage,
+			current,
+			total,
+			data
+	);
+	return set_callback_error(error_message, ret);
+}
+
+int _go_git_packbuilder_set_callbacks(git_packbuilder *pb, void *payload)
+{
+	return git_packbuilder_set_callbacks(pb, (git_packbuilder_progress)&packbuilder_progress_callback, payload);
+}
+
 static int push_transfer_progress_callback(
 		unsigned int current,
 		unsigned int total,


### PR DESCRIPTION
Add `SetCallbacks` function to packbuilder which invokes `git_packbuilder_set_callbacks` and allows packbuilder progress information to be reported back to the caller.

https://libgit2.org/libgit2/#HEAD/group/packbuilder/git_packbuilder_set_callbacks