### PR TITLE
Fix smart HTTP transport protocol handling

### DIFF
--- a/http.go
+++ b/http.go
@@ -89,7 +89,7 @@ func (t *httpSmartSubtransport) Action(url string, action SmartServiceAction) (S
 		req, err = http.NewRequest("GET", url+"/info/refs?service=git-receive-pack", nil)
 
 	case SmartServiceActionReceivepack:
-		req, err = http.NewRequest("POST", url+"/info/refs?service=git-upload-pack", nil)
+		req, err = http.NewRequest("POST", url+"/git-receive-pack", nil)
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
This fixes the smart HTTP transport implementation receive pack service to send requests to `/git-receive-pack` instead of `/info/Refs?service=git-upload-pack`.

This issue seems to stem from a bad copy-paste, because this was the only difference when comparing the traces of a git push done with `git2go` with the regular `git` client.

In case of a HTTPS push, it would before result in a `HTTP 405 Method Not Allowed` (at least on the Gitea instance I was testing it on), and it now works.